### PR TITLE
Triggered effects

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -552,3 +552,85 @@ This SL_Effect applies an Enchantment to the specified EquipmentSlot.
   <ApplyPermanently>false</ApplyPermanently>
 </SL_Effect>
 ```
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+### SL_OnHitEffect
+This SL_Effect applies it's sub-effects each time it detects a matching hit. Hits by the effect owner apply `Hit` effects on the target and `Normal` effects on the owner.
+Hits on the owner apply `Block` effects on the attacker, and `Referenced` effects on the owner. Only up to `ActivationLimit` applications are allowed on a character in the same frame.
+
+| Parameter Name | Description |
+| ---| ------------- | 
+| ChildEffects  | A list of EffectTransforms containing the effects that should be applied. |   
+| ActivationLimit  | How many times should effects be allowed to apply to each character. |   
+| RequiredSourceType  | Whether hits need to come from weapons or not. |   
+| DamageTypes  | Which damage types should trigger effects. |   
+| RequireAllTypes  | If true, each damage type is required rather than just one. |   
+| MinDamage  | How much damage must be done to trigger the effects. |   
+| OnlyCountRequiredTypes  | If true, only damage from `Damage Types` counts towards `Min Damage` |   
+| UseHighestType  | If true, only the highest type of damage counts for any conditions. |   
+| IgnoreDamageReduction  | If true, calculations are done based on damage before reductions from target's defenses. |   
+
+```xml
+<SL_Effect xsi:type="SL_OnHitEffect">
+    <Delay>0</Delay>
+    <SyncType>OwnerSync</SyncType>
+    <OverrideCategory>None</OverrideCategory>
+    <EffectBehavior>Destroy</EffectBehavior>
+    <ChildEffects>
+    </ChildEffects>
+    <ActivationLimit>3</ActivationLimit>
+    <RequiredSourceType>WEAPON</RequiredSourceType>
+    <RequireAllTypes>false</RequireAllTypes>
+    <MinDamage>0</MinDamage>
+    <OnlyCountRequiredTypes>false</OnlyCountRequiredTypes>
+    <UseHighestType>false</UseHighestType>
+    <IgnoreDamageReduction>false</IgnoreDamageReduction>
+</SL_Effect>
+```
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+### SL_OnEquipEffect
+This SL_Effect applies it's sub-effects each time it detects a change in equipped items. Equipping an item applies `Activation` and `Normal` effects. Unequipping an item applies `Normal` and `Referenced` effects. These take places *after* their action, so items will already be in/out of their equip slots when effects are resolved.
+
+| Parameter Name | Description |
+| ---| ------------- | 
+| ChildEffects  | A list of EffectTransforms containing the effects that should be applied. |
+| ActivationLimit  | How many times should effects be allowed to apply to each character. |
+| AllowedSlots  | Which equipment slots should be tracked. |
+
+```xml
+<SL_Effect xsi:type="SL_OnEquipEffect">
+    <Delay>0</Delay>
+    <SyncType>OwnerSync</SyncType>
+    <OverrideCategory>None</OverrideCategory>
+    <EffectBehavior>Destroy</EffectBehavior>
+    <ChildEffects>
+    </ChildEffects>
+    <ActivationLimit>2</ActivationLimit>
+    <AllowedSlots />
+</SL_Effect>
+```
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+### SL_EffectLifecycleEffect
+This SL_Effect applies it's sub-effects each time it is activated. The first activation applies `Activation` and `Normal` effects. Subsequent activations apply just `Normal` effects.
+Finally, the effect stopping applies `Referenced` effects.
+
+| Parameter Name | Description |
+| ---| ------------- | 
+| ChildEffects  | A list of EffectTransforms containing the effects that should be applied. |
+| ActivationLimit  | How many times should effects be allowed to apply to each character. Not used, since the effect can't activate more than once. |
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<SL_Effect xsi:type="SL_EffectLifecycleEffect">
+    <Delay>0</Delay>
+    <SyncType>OwnerSync</SyncType>
+    <OverrideCategory>None</OverrideCategory>
+    <EffectBehavior>Destroy</EffectBehavior>
+    <ChildEffects>
+    </ChildEffects>
+    <ActivationLimit>0</ActivationLimit>
+</SL_Effect>
+```
+

--- a/XML/SL_EffectLifecycleEffect.xml
+++ b/XML/SL_EffectLifecycleEffect.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<SL_Effect xsi:type="SL_EffectLifecycleEffect">
+    <Delay>0</Delay>
+    <SyncType>OwnerSync</SyncType>
+    <OverrideCategory>None</OverrideCategory>
+    <EffectBehavior>Destroy</EffectBehavior>
+    <ChildEffects>
+    <SL_EffectTransform>
+        <TransformName>Referenced End</TransformName>
+        <Position xsi:nil="true" />
+        <Rotation xsi:nil="true" />
+        <Scale xsi:nil="true" />
+        <Effects>
+        <SL_Effect xsi:type="SL_AddStatusEffect">
+            <Delay>0</Delay>
+            <SyncType>OwnerSync</SyncType>
+            <OverrideCategory>None</OverrideCategory>
+            <StatusEffect>Discipline</StatusEffect>
+            <ChanceToContract>100</ChanceToContract>
+            <AffectController>false</AffectController>
+            <AdditionalLevel>0</AdditionalLevel>
+            <NoDealer>false</NoDealer>
+        </SL_Effect>
+        </Effects>
+    </SL_EffectTransform>
+    </ChildEffects>
+    <ActivationLimit>0</ActivationLimit>
+</SL_Effect>

--- a/XML/SL_OnEquipEffect.xml
+++ b/XML/SL_OnEquipEffect.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<SL_Effect xsi:type="SL_OnEquipEffect">
+    <Delay>0</Delay>
+    <SyncType>OwnerSync</SyncType>
+    <OverrideCategory>None</OverrideCategory>
+    <EffectBehavior>Destroy</EffectBehavior>
+    <ChildEffects>
+    <SL_EffectTransform>
+        <TransformName>Normal</TransformName>
+        <Position xsi:nil="true" />
+        <Rotation xsi:nil="true" />
+        <Scale xsi:nil="true" />
+        <Effects>
+        <SL_Effect xsi:type="SL_ApplyEnchantment">
+            <Delay>0</Delay>
+            <SyncType>OwnerSync</SyncType>
+            <OverrideCategory>None</OverrideCategory>
+            <EquipmentSlot>RightHand</EquipmentSlot>
+            <EnchantmentID>-22050</EnchantmentID>
+            <ApplyPermanently>false</ApplyPermanently>
+        </SL_Effect>
+        </Effects>
+    </SL_EffectTransform>
+    </ChildEffects>
+    <ActivationLimit>2</ActivationLimit>
+    <AllowedSlots />
+</SL_Effect>

--- a/XML/SL_OnHitEffect.xml
+++ b/XML/SL_OnHitEffect.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<SL_Effect xsi:type="SL_OnHitEffect">
+    <Delay>0</Delay>
+    <SyncType>OwnerSync</SyncType>
+    <OverrideCategory>None</OverrideCategory>
+    <EffectBehavior>Destroy</EffectBehavior>
+    <ChildEffects>
+    <SL_EffectTransform>
+        <TransformName>Hit</TransformName>
+        <Position xsi:nil="true" />
+        <Rotation xsi:nil="true" />
+        <Scale xsi:nil="true" />
+        <Effects>
+        <SL_Effect xsi:type="SL_WeaponDamage">
+            <Delay>0</Delay>
+            <SyncType>OwnerSync</SyncType>
+            <OverrideCategory>None</OverrideCategory>
+            <Damage>
+            <SL_Damage>
+                <Damage>6</Damage>
+                <Type>Frost</Type>
+            </SL_Damage>
+            </Damage>
+            <Damages_AI />
+            <Knockback>0</Knockback>
+            <HitInventory>false</HitInventory>
+            <IgnoreHalfResistances>false</IgnoreHalfResistances>
+            <OverrideType>Physical</OverrideType>
+            <ForceOnlyLeftHand>false</ForceOnlyLeftHand>
+            <Damage_Multiplier>0</Damage_Multiplier>
+            <Damage_Multiplier_Kback>0</Damage_Multiplier_Kback>
+            <Damage_Multiplier_Kdown>0</Damage_Multiplier_Kdown>
+            <Impact_Multiplier>0</Impact_Multiplier>
+            <Impact_Multiplier_Kback>0</Impact_Multiplier_Kback>
+            <Impact_Multiplier_Kdown>0</Impact_Multiplier_Kdown>
+        </SL_Effect>
+        </Effects>
+    </SL_EffectTransform>
+    </ChildEffects>
+    <ActivationLimit>3</ActivationLimit>
+    <RequiredSourceType>WEAPON</RequiredSourceType>
+    <RequireAllTypes>false</RequireAllTypes>
+    <MinDamage>0</MinDamage>
+    <OnlyCountRequiredTypes>false</OnlyCountRequiredTypes>
+    <UseHighestType>false</UseHighestType>
+    <IgnoreDamageReduction>false</IgnoreDamageReduction>
+</SL_Effect>

--- a/src/Events/EquipEvent.cs
+++ b/src/Events/EquipEvent.cs
@@ -7,50 +7,40 @@ namespace SideLoader_ExtendedEffects.Events {
     public struct EquipEvent {
         public Character character;
         public Equipment item;
-        public CharacterEquipment equipment;
         public bool equipped;
-        public ItemContainer targetInventory;
+        public EquipmentSlot.EquipmentSlotIDs slot;
     }
 
-    [HarmonyPatch(typeof(CharacterEquipment), nameof(CharacterEquipment.EquipWithoutAssociating), argumentTypes:new Type[]{
-        typeof(Equipment),
-        typeof(bool)
-    })]
-    public class CharacterEquipment_EquipWithoutAssociating
+    [HarmonyPatch(typeof(EquipmentSlot), nameof(EquipmentSlot.Equip))]
+    public class EquipmentSlot_Equip
     {
         static void Postfix(
-            CharacterEquipment __instance,
-            Equipment _itemToEquip,
-            bool _playAnim = false
+            EquipmentSlot __instance,
+            Item _item
         )
         {
             var e =  new EquipEvent {
                 character   = __instance.m_character,
-                item  = _itemToEquip,
-                equipment = __instance,
+                item  = _item as Equipment,
                 equipped = true,
-                targetInventory = null
+                slot = __instance.SlotType,
             };
             Publisher<EquipEvent>.RaiseEvent(e);
         }
     }
 
-    [HarmonyPatch(typeof(CharacterEquipment), nameof(CharacterEquipment.UnequipItem))]
-    public class CharacterEquipment_UnequipItem
+    [HarmonyPatch(typeof(EquipmentSlot), nameof(EquipmentSlot.Unequip))]
+    public class EquipmentSlot_Unequip
     {
         static void Postfix(
-            CharacterEquipment __instance,
-            Equipment _itemToUnequip,
-            bool _playAnim,
-            ItemContainer _targetContainer
+            EquipmentSlot __instance
         )
         {
             var e =  new EquipEvent {
                 character   = __instance.m_character,
-                item  = _itemToUnequip,
-                equipment = __instance,
+                item = null, //The slot is always empty after unequipping
                 equipped = false,
-                targetInventory = _targetContainer
+                slot = __instance.SlotType,
             };
             Publisher<EquipEvent>.RaiseEvent(e);
         }

--- a/src/Events/EquipEvent.cs
+++ b/src/Events/EquipEvent.cs
@@ -40,14 +40,14 @@ namespace SideLoader_ExtendedEffects.Events {
     {
         static void Postfix(
             CharacterEquipment __instance,
-            Equipment _itemToEquip,
+            Equipment _itemToUnequip,
             bool _playAnim,
             ItemContainer _targetContainer
         )
         {
             var e =  new EquipEvent {
                 character   = __instance.m_character,
-                item  = _itemToEquip,
+                item  = _itemToUnequip,
                 equipment = __instance,
                 equipped = false,
                 targetInventory = _targetContainer

--- a/src/Events/EquipEvent.cs
+++ b/src/Events/EquipEvent.cs
@@ -1,0 +1,59 @@
+using System;
+using HarmonyLib;
+using UnityEngine;
+
+namespace SideLoader_ExtendedEffects.Events {
+
+    public struct EquipEvent {
+        public Character character;
+        public Equipment item;
+        public CharacterEquipment equipment;
+        public bool equipped;
+        public ItemContainer targetInventory;
+    }
+
+    [HarmonyPatch(typeof(CharacterEquipment), nameof(CharacterEquipment.EquipWithoutAssociating), argumentTypes:new Type[]{
+        typeof(Equipment),
+        typeof(bool)
+    })]
+    public class CharacterEquipment_EquipWithoutAssociating
+    {
+        static void Postfix(
+            CharacterEquipment __instance,
+            Equipment _itemToEquip,
+            bool _playAnim = false
+        )
+        {
+            var e =  new EquipEvent {
+                character   = __instance.m_character,
+                item  = _itemToEquip,
+                equipment = __instance,
+                equipped = true,
+                targetInventory = null
+            };
+            Publisher<EquipEvent>.RaiseEvent(e);
+        }
+    }
+
+    [HarmonyPatch(typeof(CharacterEquipment), nameof(CharacterEquipment.UnequipItem))]
+    public class CharacterEquipment_UnequipItem
+    {
+        static void Postfix(
+            CharacterEquipment __instance,
+            Equipment _itemToEquip,
+            bool _playAnim,
+            ItemContainer _targetContainer
+        )
+        {
+            var e =  new EquipEvent {
+                character   = __instance.m_character,
+                item  = _itemToEquip,
+                equipment = __instance,
+                equipped = false,
+                targetInventory = _targetContainer
+            };
+            Publisher<EquipEvent>.RaiseEvent(e);
+        }
+    }
+
+}

--- a/src/Events/HitEvent.cs
+++ b/src/Events/HitEvent.cs
@@ -1,0 +1,51 @@
+using HarmonyLib;
+using UnityEngine;
+using SideLoader;
+
+namespace SideLoader_ExtendedEffects.Events {
+
+    public struct HitEvent {
+        public Character source;
+        public Character target;
+        public float totalDamage;
+        public DamageList damage;
+        public Vector3 hitDirection;
+        public Vector3 hitLocation;
+        public float angle;
+        public float angleDirection;
+        public Weapon weapon;
+        public float knockback;
+    }
+
+    [HarmonyPatch(typeof(Character), nameof(Character.OnReceiveHit))]
+    public class Character_RecieveHit_Postfix
+    {
+        static void Postfix(
+            Character __instance,
+            Weapon _weapon,
+            float _damage,
+            DamageList _damageList,
+            Vector3 _hitDir,
+            Vector3 _hitPoint,
+            float _angle,
+            float _angleDir,
+            Character _dealerChar,
+            float _knockBack)
+        {
+            var e =  new HitEvent {
+                source   = _dealerChar,
+                target  = __instance,
+                totalDamage = _damage,
+                damage = _damageList,
+                hitDirection = _hitDir,
+                hitLocation = _hitPoint,
+                angle = _angle,
+                angleDirection = _angleDir,
+                weapon = _weapon,
+                knockback = _knockBack
+            };
+            Publisher<HitEvent>.RaiseEvent(e);
+        }
+    }
+
+}

--- a/src/Events/HitEvent.cs
+++ b/src/Events/HitEvent.cs
@@ -1,47 +1,56 @@
+using System;
 using HarmonyLib;
 using UnityEngine;
-using SideLoader;
 
 namespace SideLoader_ExtendedEffects.Events {
 
     public struct HitEvent {
-        public Character source;
+        public Character dealer;
         public Character target;
-        public float totalDamage;
         public DamageList damage;
         public Vector3 hitDirection;
         public Vector3 hitLocation;
         public float angle;
         public float angleDirection;
-        public Weapon weapon;
+        public EffectSynchronizer source;
         public float knockback;
     }
 
-    [HarmonyPatch(typeof(Character), nameof(Character.OnReceiveHit))]
+    [HarmonyPatch(typeof(Character), nameof(Character.ReceiveHit), argumentTypes:new Type[]{
+        typeof(UnityEngine.Object),
+        typeof(DamageList),
+        typeof(Vector3),
+        typeof(Vector3),
+        typeof(float),
+        typeof(float),
+        typeof(Character),
+        typeof(float),
+        typeof(bool)
+    })]
     public class Character_RecieveHit_Postfix
     {
         static void Postfix(
             Character __instance,
-            Weapon _weapon,
-            float _damage,
-            DamageList _damageList,
+            UnityEngine.Object _damageSource,
+            DamageList _damage,
             Vector3 _hitDir,
             Vector3 _hitPoint,
             float _angle,
             float _angleDir,
             Character _dealerChar,
-            float _knockBack)
+            float _knockBack,
+            bool _hitInventory
+        )
         {
             var e =  new HitEvent {
-                source   = _dealerChar,
+                dealer   = _dealerChar,
                 target  = __instance,
-                totalDamage = _damage,
-                damage = _damageList,
+                damage = _damage,
                 hitDirection = _hitDir,
                 hitLocation = _hitPoint,
                 angle = _angle,
                 angleDirection = _angleDir,
-                weapon = _weapon,
+                source = _damageSource as EffectSynchronizer,
                 knockback = _knockBack
             };
             Publisher<HitEvent>.RaiseEvent(e);

--- a/src/Events/Publisher.cs
+++ b/src/Events/Publisher.cs
@@ -9,7 +9,7 @@ namespace SideLoader_ExtendedEffects.Events
         public static event EventHandler<Event> Handler;
         public static void RaiseEvent(Event args) {
             SL.Log("Number of handlers: " + Handler.GetInvocationList().Length);
-            Handler.Invoke(null, args);
+            Handler?.Invoke(null, args);
         }
     }
 

--- a/src/Events/Publisher.cs
+++ b/src/Events/Publisher.cs
@@ -1,0 +1,16 @@
+using System;
+using SideLoader;
+
+namespace SideLoader_ExtendedEffects.Events
+{
+
+    public class Publisher<Event> where Event: struct
+    {
+        public static event EventHandler<Event> Handler;
+        public static void RaiseEvent(Event args) {
+            SL.Log("Number of handlers: " + Handler.GetInvocationList().Length);
+            Handler.Invoke(null, args);
+        }
+    }
+
+}

--- a/src/Events/Publisher.cs
+++ b/src/Events/Publisher.cs
@@ -8,7 +8,7 @@ namespace SideLoader_ExtendedEffects.Events
     {
         public static event EventHandler<Event> Handler;
         public static void RaiseEvent(Event args) {
-            SL.Log("Number of handlers: " + Handler.GetInvocationList().Length);
+            SL.Log("Number of handlers: " + Handler?.GetInvocationList().Length);
             Handler?.Invoke(null, args);
         }
     }

--- a/src/Released/ContainerEffects/EffectLifecycleEffect.cs
+++ b/src/Released/ContainerEffects/EffectLifecycleEffect.cs
@@ -1,0 +1,32 @@
+
+
+namespace SideLoader_ExtendedEffects.Containers
+{
+
+    public class SL_EffectLifecycleEffect: SL_ParentEffect {
+    }
+
+    public class EffectLifecycleEffect : ParentEffect
+    {
+        private bool activated = false;
+        public override void ActivateLocally(Character _affectedCharacter, object[] _infos)
+        {
+            if (!activated) {
+                this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Activation, this.OwnerCharacter);
+                activated = true;
+            }
+            this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Normal, this.OwnerCharacter);
+        }
+        public override void StopAffectLocally(Character _affectedCharacter)
+        {
+            this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Reference, this.OwnerCharacter);
+            this.activated = false;
+            
+            this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Activation, this.OwnerCharacter);
+            this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Normal, this.OwnerCharacter);
+            this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Reference, this.OwnerCharacter);
+            base.StopAffectLocally(_affectedCharacter);
+        }
+    }
+
+}

--- a/src/Released/ContainerEffects/EffectLifecycleEffect.cs
+++ b/src/Released/ContainerEffects/EffectLifecycleEffect.cs
@@ -1,4 +1,5 @@
-
+using SideLoader;
+using System;
 
 namespace SideLoader_ExtendedEffects.Containers
 {
@@ -6,8 +7,12 @@ namespace SideLoader_ExtendedEffects.Containers
     public class SL_EffectLifecycleEffect: SL_ParentEffect {
     }
 
-    public class EffectLifecycleEffect : ParentEffect
+    public class EffectLifecycleEffect : ParentEffect, ICustomModel
     {
+
+        public Type SLTemplateModel => typeof(SL_EffectLifecycleEffect);
+        public Type GameModel => typeof(EffectLifecycleEffect);
+
         private bool activated = false;
         public override void ActivateLocally(Character _affectedCharacter, object[] _infos)
         {
@@ -20,11 +25,11 @@ namespace SideLoader_ExtendedEffects.Containers
         public override void StopAffectLocally(Character _affectedCharacter)
         {
             this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Reference, this.OwnerCharacter);
-            this.activated = false;
+            this.activated = false; 
             
+            this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Reference, this.OwnerCharacter);
             this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Activation, this.OwnerCharacter);
             this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Normal, this.OwnerCharacter);
-            this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Reference, this.OwnerCharacter);
             base.StopAffectLocally(_affectedCharacter);
         }
     }

--- a/src/Released/ContainerEffects/ParentEffect.cs
+++ b/src/Released/ContainerEffects/ParentEffect.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using SideLoader;
+using UnityEngine;
+
+namespace SideLoader_ExtendedEffects.Containers
+{
+
+    public abstract class SL_ParentEffect : SL_Effect
+    {
+        public EditBehaviours EffectBehavior = EditBehaviours.Destroy;
+        public SL_EffectTransform[] ChildEffects;
+        public override void ApplyToComponent<T>(T component)
+        {
+            try {
+                var comp = component as ParentEffect;
+
+                var obj = new GameObject();
+                GameObject.DontDestroyOnLoad(obj);
+                obj.SetActive(false);
+
+                comp.ChildEffects = obj.gameObject.AddComponent<SubEffect>();
+                SL_EffectTransform.ApplyTransformList(comp.ChildEffects.transform, ChildEffects, EffectBehavior);
+                SL.Log(ChildEffects.Length);
+                SL.Log(comp.ChildEffects.transform.childCount);
+            } catch (Exception e) {
+                SL.Log(e);
+            }
+        }
+
+        public override void SerializeEffect<T>(T effect)
+        {
+            try {
+                var comp = effect as ParentEffect;
+                if (comp.ChildEffects.transform.childCount > 0) {
+                    List<SL_EffectTransform> list = new List<SL_EffectTransform>();
+                    foreach (Transform child in comp.ChildEffects.transform)
+                    {
+                        SL_EffectTransform effectsChild = SL_EffectTransform.ParseTransform(child);
+
+                        if (effectsChild.HasContent)
+                        {
+                            list.Add(effectsChild);
+                        }
+                    }
+                    ChildEffects = list.ToArray();
+                }
+            } catch (Exception e) {
+                SL.Log(e);
+            }
+        }
+    }
+
+    public abstract class ParentEffect: Shooter {
+
+        public SubEffect ChildEffects;
+
+        public override void Setup(Character.Factions[] _targetFactions, Transform _parent)
+        {
+            try {
+                SL.Log("Set Up");
+                SL.Log("own parent: " + this.m_parentSynchronizer.name);
+                base.Setup(_targetFactions, _parent);
+                
+                if (this.m_subEffects == null)
+                {
+                    this.m_subEffects = new SubEffect[] {
+                        UnityEngine.Object.Instantiate<SubEffect>(this.ChildEffects)
+                    };
+                }
+                this.m_subEffects[0].gameObject.SetActive(true);
+                this.m_subEffects[0].Setup(this, 0, _targetFactions, _parent);
+                SL.Log(this.m_subEffects[0].m_parentEffect);
+                this.m_subEffects[0].m_parentEffect = this;
+                foreach (Effect effect in this.m_subEffects[0].transform.GetComponentsInChildren<Effect>()) {
+                    //effect.StartInit();
+                }
+            } catch (Exception e) {
+                SL.Log("=========Setup Error!===========");
+                SL.Log(e);
+            }
+        }
+
+        // Always gotta clean up, so that might as well be on the parent class.
+        public override void StopAffectLocally(Character _affectedCharacter)
+        {
+            foreach (EffectSynchronizer.EffectCategories category in Enum.GetValues(typeof(EffectSynchronizer.EffectCategories))) {
+                ChildEffects.StopAllEffects(category, _affectedCharacter);
+            }
+            base.StopAffectLocally(_affectedCharacter);
+        }
+    }
+
+
+}

--- a/src/Released/ContainerEffects/TriggeredEffects/OnEquipEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/OnEquipEffect.cs
@@ -39,15 +39,11 @@ namespace SideLoader_ExtendedEffects.Containers.Triggers
             if (args.equipped) {
                 StartApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Activation, EffectSynchronizer.EffectCategories.Normal},
                     args.character, args.character.m_lastPosition, args.character.m_lastForward);
-                StopApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Activation},
-                    args.character);
             }
             else
             {
-                StartApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Reference},
+                StartApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Reference, EffectSynchronizer.EffectCategories.Normal},
                     args.character, args.character.m_lastPosition, args.character.m_lastForward);
-                StopApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Reference, EffectSynchronizer.EffectCategories.Normal},
-                    args.character);
             }
 
         }

--- a/src/Released/ContainerEffects/TriggeredEffects/OnEquipEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/OnEquipEffect.cs
@@ -1,7 +1,6 @@
 using SideLoader_ExtendedEffects.Events;
 using SideLoader;
 using System;
-using System.Collections.Generic;
 
 namespace SideLoader_ExtendedEffects.Containers.Triggers
 {
@@ -32,16 +31,20 @@ namespace SideLoader_ExtendedEffects.Containers.Triggers
 
         public override void OnEvent(object sender, EquipEvent args)
         {
-            if (!AllowedSlots.Contains(args.item.EquipSlot)) {
+            if (args.character != this.OwnerCharacter) {
+                return;
+            }
+            if (AllowedSlots != null && AllowedSlots.Length > 0 && !AllowedSlots.Contains(args.slot)) {
                 return; // Not one of the tracked slots
             }
-
             if (args.equipped) {
+                SL.Log("Equipped item");
                 StartApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Activation, EffectSynchronizer.EffectCategories.Normal},
                     args.character, args.character.m_lastPosition, args.character.m_lastForward);
             }
             else
             {
+                SL.Log("Unequipped item");
                 StartApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Reference, EffectSynchronizer.EffectCategories.Normal},
                     args.character, args.character.m_lastPosition, args.character.m_lastForward);
             }

--- a/src/Released/ContainerEffects/TriggeredEffects/OnEquipEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/OnEquipEffect.cs
@@ -1,0 +1,65 @@
+using SideLoader_ExtendedEffects.Events;
+using SideLoader;
+using System;
+using System.Collections.Generic;
+
+namespace SideLoader_ExtendedEffects.Containers.Triggers
+{
+
+    public class SL_OnEquipEffect: SL_ParentEffect {
+        public EquipmentSlot.EquipmentSlotIDs[] AllowedSlots;
+
+        public OnEquipEffect.Action AllowedAction;
+
+        public override void ApplyToComponent<T>(T component)
+        {
+            base.ApplyToComponent<T>(component);
+            var comp = component as OnEquipEffect;
+            comp.AllowedSlots = this.AllowedSlots;
+            comp.AllowedAction = this.AllowedAction;
+        }
+        public override void SerializeEffect<T>(T effect)
+        {
+            base.SerializeEffect<T>(effect);
+            var comp = effect as OnEquipEffect;
+            this.AllowedSlots = comp.AllowedSlots;
+            this.AllowedAction = comp.AllowedAction;
+        }
+
+    }
+
+    public class OnEquipEffect : TriggeredEffect<EquipEvent>, ICustomModel
+    {
+        public enum Action {
+            EQUIP,
+            UNEQUIP,
+            ANY
+        }
+
+        public Type SLTemplateModel => typeof(SL_OnEquipEffect);
+        public Type GameModel => typeof(OnEquipEffect);
+        public Action AllowedAction;
+        public EquipmentSlot.EquipmentSlotIDs[] AllowedSlots;
+
+        public override void OnEvent(object sender, EquipEvent args)
+        {
+            if (!AllowedSlots.Contains(args.item.EquipSlot)) {
+                return; // Not one of the tracked slots
+            }
+
+            if (
+                (AllowedAction == Action.EQUIP && !args.equipped) ||
+                (AllowedAction == Action.UNEQUIP && args.equipped)
+            )
+            {
+                return; //Not a tracked action
+            }
+
+            List<EffectSynchronizer.EffectCategories> effectList = new List<EffectSynchronizer.EffectCategories>();
+            ApplyTo(effectList.ToArray(), args.character, args.character.m_lastPosition, args.character.m_lastForward);
+
+        }
+
+    }
+
+}

--- a/src/Released/ContainerEffects/TriggeredEffects/OnEquipEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/OnEquipEffect.cs
@@ -9,36 +9,25 @@ namespace SideLoader_ExtendedEffects.Containers.Triggers
     public class SL_OnEquipEffect: SL_ParentEffect {
         public EquipmentSlot.EquipmentSlotIDs[] AllowedSlots;
 
-        public OnEquipEffect.Action AllowedAction;
-
         public override void ApplyToComponent<T>(T component)
         {
             base.ApplyToComponent<T>(component);
             var comp = component as OnEquipEffect;
             comp.AllowedSlots = this.AllowedSlots;
-            comp.AllowedAction = this.AllowedAction;
         }
         public override void SerializeEffect<T>(T effect)
         {
             base.SerializeEffect<T>(effect);
             var comp = effect as OnEquipEffect;
             this.AllowedSlots = comp.AllowedSlots;
-            this.AllowedAction = comp.AllowedAction;
         }
 
     }
 
     public class OnEquipEffect : TriggeredEffect<EquipEvent>, ICustomModel
     {
-        public enum Action {
-            EQUIP,
-            UNEQUIP,
-            ANY
-        }
-
         public Type SLTemplateModel => typeof(SL_OnEquipEffect);
         public Type GameModel => typeof(OnEquipEffect);
-        public Action AllowedAction;
         public EquipmentSlot.EquipmentSlotIDs[] AllowedSlots;
 
         public override void OnEvent(object sender, EquipEvent args)
@@ -47,16 +36,19 @@ namespace SideLoader_ExtendedEffects.Containers.Triggers
                 return; // Not one of the tracked slots
             }
 
-            if (
-                (AllowedAction == Action.EQUIP && !args.equipped) ||
-                (AllowedAction == Action.UNEQUIP && args.equipped)
-            )
-            {
-                return; //Not a tracked action
+            if (args.equipped) {
+                StartApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Activation, EffectSynchronizer.EffectCategories.Normal},
+                    args.character, args.character.m_lastPosition, args.character.m_lastForward);
+                StopApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Activation},
+                    args.character);
             }
-
-            List<EffectSynchronizer.EffectCategories> effectList = new List<EffectSynchronizer.EffectCategories>();
-            ApplyTo(effectList.ToArray(), args.character, args.character.m_lastPosition, args.character.m_lastForward);
+            else
+            {
+                StartApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Reference},
+                    args.character, args.character.m_lastPosition, args.character.m_lastForward);
+                StopApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Reference, EffectSynchronizer.EffectCategories.Normal},
+                    args.character);
+            }
 
         }
 

--- a/src/Released/ContainerEffects/TriggeredEffects/OnHitEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/OnHitEffect.cs
@@ -1,0 +1,68 @@
+using SideLoader_ExtendedEffects.Events;
+using SideLoader;
+using System;
+
+namespace SideLoader_ExtendedEffects.Containers.Triggers
+{
+
+    public class SL_OnHitEffect: SL_ParentEffect {}
+
+    public class OnHitEffect : TriggeredEffect<HitEvent>, ICustomModel
+    {
+        public Type SLTemplateModel => typeof(SL_OnHitEffect);
+
+        public Type GameModel => typeof(OnHitEffect);
+
+        public enum DamageSourceType {
+            ALL,
+            WEAPON,
+            NON_WEAPON
+        }
+
+        public DamageSourceType RequiredSourceType;
+        public DamageType[] DamageTypes;
+        public bool RequireAllTypes;
+        public int MinDamage;
+        public bool OnlyCountRequiredTypes;
+
+        public override void OnEvent(object sender, HitEvent args)
+        {
+            try{
+                
+
+                if (args.target == this.OwnerCharacter) // Effect owner is the target
+                {
+                    try {
+                        // apply block effects to the source of the hit (usually an enemy hitting the buff owner)
+                        this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Block, args.source, args.hitLocation, args.hitDirection);
+                        this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Block, args.source);
+                        // apply reference effects to the target of the hit (the owner of the effect)
+                        this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Reference, args.target, args.hitLocation, args.hitDirection);
+                        this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Reference, args.target);
+                    } catch (Exception e) {
+                        SL.Log(e);
+                    }
+                }
+                if (args.source == this.OwnerCharacter) // Effect owner dealt the hit; 
+                {
+                    try {
+                        // apply hit effects to the target
+                        this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Hit, args.target, args.hitLocation, args.hitDirection);
+                        this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Hit, args.target);
+                        // apply normal effects to the owner
+                        this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Normal, args.source, args.hitLocation, args.hitDirection);
+                        this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Normal, args.source);
+                    } catch (Exception e) {
+                        SL.Log(e);
+                    }
+                }
+            } catch (Exception e) {
+                SL.Log("=============Hit Event Error============");
+                SL.Log(e);
+            }
+            
+        }
+
+    }
+
+}

--- a/src/Released/ContainerEffects/TriggeredEffects/OnHitEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/OnHitEffect.cs
@@ -1,11 +1,46 @@
 using SideLoader_ExtendedEffects.Events;
 using SideLoader;
 using System;
+using System.Collections.Generic;
 
 namespace SideLoader_ExtendedEffects.Containers.Triggers
 {
 
-    public class SL_OnHitEffect: SL_ParentEffect {}
+    public class SL_OnHitEffect: SL_ParentEffect {
+        public OnHitEffect.DamageSourceType RequiredSourceType;
+        public DamageType.Types[] DamageTypes;
+        public bool RequireAllTypes;
+        public int MinDamage;
+        public bool OnlyCountRequiredTypes;
+        public bool UseHighestType;
+        public bool IgnoreDamageReduction;
+
+        public override void ApplyToComponent<T>(T component)
+        {
+            base.ApplyToComponent<T>(component);
+            var comp = component as OnHitEffect;
+            comp.RequiredSourceType = this.RequiredSourceType;
+            comp.DamageTypes = this.DamageTypes;
+            comp.RequireAllTypes = this.RequireAllTypes;
+            comp.MinDamage = this.MinDamage;
+            comp.OnlyCountRequiredTypes = this.OnlyCountRequiredTypes;
+            comp.UseHighestType = this.UseHighestType;
+            comp.IgnoreDamageReduction = this.IgnoreDamageReduction;
+        }
+        public override void SerializeEffect<T>(T effect)
+        {
+            base.SerializeEffect<T>(effect);
+            var comp = effect as OnHitEffect;
+            this.RequiredSourceType = comp.RequiredSourceType;
+            this.DamageTypes = comp.DamageTypes;
+            this.RequireAllTypes = comp.RequireAllTypes;
+            this.MinDamage = comp.MinDamage;
+            this.OnlyCountRequiredTypes = comp.OnlyCountRequiredTypes;
+            this.UseHighestType = comp.UseHighestType;
+            this.IgnoreDamageReduction = comp.IgnoreDamageReduction;
+        }
+
+    }
 
     public class OnHitEffect : TriggeredEffect<HitEvent>, ICustomModel
     {
@@ -14,47 +49,133 @@ namespace SideLoader_ExtendedEffects.Containers.Triggers
         public Type GameModel => typeof(OnHitEffect);
 
         public enum DamageSourceType {
-            ALL,
+            ANY,
             WEAPON,
             NON_WEAPON
         }
 
         public DamageSourceType RequiredSourceType;
-        public DamageType[] DamageTypes;
+        public DamageType.Types[] DamageTypes;
         public bool RequireAllTypes;
         public int MinDamage;
         public bool OnlyCountRequiredTypes;
+        public bool UseHighestType;
+        public bool IgnoreDamageReduction;
 
         public override void OnEvent(object sender, HitEvent args)
         {
             try{
-                
+                //Check if the hit was made with a weapon
+                if (
+                    (RequiredSourceType == DamageSourceType.NON_WEAPON && args.source is Weapon) ||
+                    (RequiredSourceType == DamageSourceType.WEAPON && !(args.source is Weapon))
+                )
+                {
+                    SL.Log("Wrong Hit Type");
+                    return; // Wrong type of hit
+                }
+                if (!IgnoreDamageReduction)
+                {
 
+                    // Sine the hook is pre-damage reduction, we need to process that ourselves
+                    if (args.source is Weapon)
+                    {
+                        args.target.ProcessDamageReduction(args.source as Weapon, args.damage, false);
+                    }
+                    else if (args.source is StatusEffect)
+                    {
+                        args.target.ProcessDamageReduction(null, args.damage, (args.source as StatusEffect).IgnoreBarrier);
+                    }
+                    else
+                    {
+                        args.target.ProcessDamageReduction(null, args.damage, false);
+                    }
+                }
+                // Highest Type variants of checks
+                if (UseHighestType)
+                {
+                    int highestType = args.damage.GetDTypeOfHighestDamage((List<int>)(DamageType.TypeList));
+                    if (DamageTypes != null && DamageTypes.Length != 0)
+                    {
+                        if (
+                            (DamageTypes != null && DamageTypes.Length > 1 && RequireAllTypes) || // Requiers multiple types, but can only match one
+                            (!DamageTypes.Contains(args.damage[highestType].Type)) // Highest types isn't among required
+                        )
+                        {
+                        SL.Log("Highest Damage Type Wrong");
+                            return; 
+                        }
+                    }
+
+                    if (args.damage[highestType].Damage < MinDamage)
+                    {
+                    SL.Log("Highest Damage Too Low");
+                        return; // Highest damage type doesn't pass minimum
+                    }
+                }
+                else
+                {
+                    if (RequireAllTypes)
+                    {
+                        foreach (var type in DamageTypes)
+                        {
+                            if (!args.damage.Contains(type)) 
+                            {
+                    SL.Log("Not All Types Present");
+                                return; // If the type doesn't appear in the hit, not all required types are there.
+                            }
+                        }
+                    }
+                    else if (DamageTypes != null && DamageTypes.Length != 0)
+                    {
+                        foreach (var type in DamageTypes)
+                        {
+                            bool found = false;
+                            if (args.damage.Contains(type)) 
+                            {
+                                found = true;
+                                break;
+                            }
+                            if (!found)
+                            {
+                            SL.Log("None Of Types Present");
+                                return; // Not one of the types was represented
+                            }
+                        }
+                    }
+                }
+
+                List<EffectSynchronizer.EffectCategories> dealerList = new List<EffectSynchronizer.EffectCategories>();
+                List<EffectSynchronizer.EffectCategories> targetList = new List<EffectSynchronizer.EffectCategories>();
                 if (args.target == this.OwnerCharacter) // Effect owner is the target
                 {
                     try {
                         // apply block effects to the source of the hit (usually an enemy hitting the buff owner)
-                        this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Block, args.source, args.hitLocation, args.hitDirection);
-                        this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Block, args.source);
+                        dealerList.Add(EffectSynchronizer.EffectCategories.Block);
                         // apply reference effects to the target of the hit (the owner of the effect)
-                        this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Reference, args.target, args.hitLocation, args.hitDirection);
-                        this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Reference, args.target);
+                        targetList.Add(EffectSynchronizer.EffectCategories.Reference);
                     } catch (Exception e) {
                         SL.Log(e);
                     }
                 }
-                if (args.source == this.OwnerCharacter) // Effect owner dealt the hit; 
+                if (args.dealer == this.OwnerCharacter) // Effect owner dealt the hit; 
                 {
-                    try {
-                        // apply hit effects to the target
-                        this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Hit, args.target, args.hitLocation, args.hitDirection);
-                        this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Hit, args.target);
-                        // apply normal effects to the owner
-                        this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Normal, args.source, args.hitLocation, args.hitDirection);
-                        this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Normal, args.source);
-                    } catch (Exception e) {
-                        SL.Log(e);
-                    }
+                    // Apply Hit effects to target
+                    targetList.Add(EffectSynchronizer.EffectCategories.Hit);
+                    // Apply Normal effects to source
+                    dealerList.Add(EffectSynchronizer.EffectCategories.Normal);
+                }
+                // Actually apply all of the required effects.
+                // Uses apply helper to make sure only one application per update happens
+                if (args.dealer == args.target)
+                {
+                    dealerList.AddRange(targetList);
+                    ApplyTo(dealerList.ToArray(), args.dealer, args.hitLocation, args.hitDirection);
+                }
+                else
+                {
+                    ApplyTo(dealerList.ToArray(), args.dealer, args.hitLocation, args.hitDirection);
+                    ApplyTo(targetList.ToArray(), args.target, args.hitLocation, args.hitDirection);
                 }
             } catch (Exception e) {
                 SL.Log("=============Hit Event Error============");

--- a/src/Released/ContainerEffects/TriggeredEffects/OnHitEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/OnHitEffect.cs
@@ -170,12 +170,12 @@ namespace SideLoader_ExtendedEffects.Containers.Triggers
                 if (args.dealer == args.target)
                 {
                     dealerList.AddRange(targetList);
-                    ApplyTo(dealerList.ToArray(), args.dealer, args.hitLocation, args.hitDirection);
+                    Apply(dealerList.ToArray(), args.dealer, args.hitLocation, args.hitDirection);
                 }
                 else
                 {
-                    ApplyTo(dealerList.ToArray(), args.dealer, args.hitLocation, args.hitDirection);
-                    ApplyTo(targetList.ToArray(), args.target, args.hitLocation, args.hitDirection);
+                    Apply(dealerList.ToArray(), args.dealer, args.hitLocation, args.hitDirection);
+                    Apply(targetList.ToArray(), args.target, args.hitLocation, args.hitDirection);
                 }
             } catch (Exception e) {
                 SL.Log("=============Hit Event Error============");

--- a/src/Released/ContainerEffects/TriggeredEffects/TriggeredEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/TriggeredEffect.cs
@@ -1,12 +1,16 @@
 using SideLoader_ExtendedEffects.Events;
 using SideLoader;
 using System;
+using UnityEngine;
+using System.Collections.Generic;
 
 namespace SideLoader_ExtendedEffects.Containers.Triggers {
 
     public abstract class TriggeredEffect<Event>: ParentEffect where Event: struct
     {
         private bool registered = false;
+        private float lastTriggerTime = 0;
+        private List<Character> affectedThisInterval;
         public override void ActivateLocally(Character _affectedCharacter, object[] _infos)
         {
             if (!registered) {
@@ -29,6 +33,30 @@ namespace SideLoader_ExtendedEffects.Containers.Triggers {
                 SL.Log("Event not registered");
             }
             base.StopAffectLocally(_affectedCharacter);
+        }
+        
+        public virtual void ApplyTo(EffectSynchronizer.EffectCategories[] categories, Character affectedCharacter, Vector3 pos, Vector3 dir) {
+            if (Time.time - this.lastTriggerTime > 0)
+            {
+                this.lastTriggerTime = Time.time;
+                if (this.affectedThisInterval == null)
+                {
+                    this.affectedThisInterval = new List<Character>();
+                }
+                else
+                {
+                    this.affectedThisInterval.Clear();
+                }
+            }
+            if (!this.affectedThisInterval.Contains(affectedCharacter))
+            {
+                this.affectedThisInterval.Add(affectedCharacter);
+                foreach (var category in categories)
+                {
+                    this.m_subEffects[0].SynchronizeEffects(category, affectedCharacter, pos, dir);
+                    this.m_subEffects[0].StopAllEffects(category, affectedCharacter);
+                }
+            }
         }
 
         public abstract void OnEvent(object sender, Event args);

--- a/src/Released/ContainerEffects/TriggeredEffects/TriggeredEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/TriggeredEffect.cs
@@ -1,16 +1,13 @@
 using SideLoader_ExtendedEffects.Events;
 using SideLoader;
 using System;
-using UnityEngine;
-using System.Collections.Generic;
 
 namespace SideLoader_ExtendedEffects.Containers.Triggers {
 
     public abstract class TriggeredEffect<Event>: ParentEffect where Event: struct
-    {
+    {   
         private bool registered = false;
-        private float lastTriggerTime = 0;
-        private List<Character> affectedThisInterval;
+
         public override void ActivateLocally(Character _affectedCharacter, object[] _infos)
         {
             if (!registered) {
@@ -33,41 +30,6 @@ namespace SideLoader_ExtendedEffects.Containers.Triggers {
                 SL.Log("Event not registered");
             }
             base.StopAffectLocally(_affectedCharacter);
-        }
-        
-        public virtual void StartApply(EffectSynchronizer.EffectCategories[] categories, Character affectedCharacter, Vector3 pos, Vector3 dir) {
-            if (Time.time - this.lastTriggerTime > 0)
-            {
-                this.lastTriggerTime = Time.time;
-                if (this.affectedThisInterval == null)
-                {
-                    this.affectedThisInterval = new List<Character>();
-                }
-                else
-                {
-                    this.affectedThisInterval.Clear();
-                }
-            }
-            if (!this.affectedThisInterval.Contains(affectedCharacter))
-            {
-                this.affectedThisInterval.Add(affectedCharacter);
-                foreach (var category in categories)
-                {
-                    this.m_subEffects[0].SynchronizeEffects(category, affectedCharacter, pos, dir);
-                }
-            }
-        }
-        public virtual void StopApply(EffectSynchronizer.EffectCategories[] categories, Character affectedCharacter)
-        {
-            foreach (var category in categories)
-            {
-                this.m_subEffects[0].StopAllEffects(category, affectedCharacter);
-            }
-        }
-
-        public virtual void Apply(EffectSynchronizer.EffectCategories[] categories, Character affectedCharacter, Vector3 pos, Vector3 dir) {
-            StartApply(categories, affectedCharacter, pos, dir);
-            StopApply(categories, affectedCharacter);
         }
 
         public abstract void OnEvent(object sender, Event args);

--- a/src/Released/ContainerEffects/TriggeredEffects/TriggeredEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/TriggeredEffect.cs
@@ -1,0 +1,37 @@
+using SideLoader_ExtendedEffects.Events;
+using SideLoader;
+using System;
+
+namespace SideLoader_ExtendedEffects.Containers.Triggers {
+
+    public abstract class TriggeredEffect<Event>: ParentEffect where Event: struct
+    {
+        private bool registered = false;
+        public override void ActivateLocally(Character _affectedCharacter, object[] _infos)
+        {
+            if (!registered) {
+                SL.Log("Registering Event");
+                SL.Log(((EventHandler<Event>)OnEvent).Method.DeclaringType);
+                Publisher<Event>.Handler += OnEvent;
+                registered = true;
+            } else {
+                SL.Log("Event already registered");
+            }
+        }
+
+        public override void StopAffectLocally(Character _affectedCharacter)
+        { 
+            if (registered) {
+                SL.Log("Deregistering Event");
+                Publisher<Event>.Handler -= OnEvent;
+                registered = false;
+            } else {
+                SL.Log("Event not registered");
+            }
+            base.StopAffectLocally(_affectedCharacter);
+        }
+
+        public abstract void OnEvent(object sender, Event args);
+    }
+
+}

--- a/src/Released/ContainerEffects/TriggeredEffects/TriggeredEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/TriggeredEffect.cs
@@ -35,7 +35,7 @@ namespace SideLoader_ExtendedEffects.Containers.Triggers {
             base.StopAffectLocally(_affectedCharacter);
         }
         
-        public virtual void ApplyTo(EffectSynchronizer.EffectCategories[] categories, Character affectedCharacter, Vector3 pos, Vector3 dir) {
+        public virtual void StartApply(EffectSynchronizer.EffectCategories[] categories, Character affectedCharacter, Vector3 pos, Vector3 dir) {
             if (Time.time - this.lastTriggerTime > 0)
             {
                 this.lastTriggerTime = Time.time;
@@ -54,9 +54,20 @@ namespace SideLoader_ExtendedEffects.Containers.Triggers {
                 foreach (var category in categories)
                 {
                     this.m_subEffects[0].SynchronizeEffects(category, affectedCharacter, pos, dir);
-                    this.m_subEffects[0].StopAllEffects(category, affectedCharacter);
                 }
             }
+        }
+        public virtual void StopApply(EffectSynchronizer.EffectCategories[] categories, Character affectedCharacter)
+        {
+            foreach (var category in categories)
+            {
+                this.m_subEffects[0].StopAllEffects(category, affectedCharacter);
+            }
+        }
+
+        public virtual void Apply(EffectSynchronizer.EffectCategories[] categories, Character affectedCharacter, Vector3 pos, Vector3 dir) {
+            StartApply(categories, affectedCharacter, pos, dir);
+            StopApply(categories, affectedCharacter);
         }
 
         public abstract void OnEvent(object sender, Event args);

--- a/src/Released/SL_ApplyEnchantment.cs
+++ b/src/Released/SL_ApplyEnchantment.cs
@@ -86,6 +86,7 @@ namespace SideLoader_ExtendedEffects
 					{
 						item.SetDurabilityRatio(durabilityRatio);
 					}
+                    break;
                 }
             }
             affectedItem = UID.Empty;

--- a/src/Released/SL_HidePlayer.cs
+++ b/src/Released/SL_HidePlayer.cs
@@ -44,6 +44,7 @@ namespace SideLoader_ExtendedEffects
 
         public override void ActivateLocally(Character _affectedCharacter, object[] _infos)
         {
+            SL.Log("Activating Locally");
             if (!IsRunning)
             {
                 StartCoroutine(ToggleCharacterVisual(this.OwnerCharacter));


### PR DESCRIPTION
Adds an effect that activates other effects on hit, and the groundwork necessary for similar effects.

Code Features:
- Publisher, A fully generic static event publisher class.
- ParentEffect, a parent which acts as a more generic Shooter that works with normal SubEffects.
- TriggeredEffect, another parent class that handles registering and deregistering from Publishers, as well as logic to prevent effect applications from recursing by limiting activations to one per character per update.
- HitEvent, a struct for use with Publisher. Includes a patch on the ReceiveHit method of Character to raise hit events.

SL Features:
- OnHitEffect, an effect that triggers it's SubEffects when a hit is detected. Uses Block, Reference, Hit, and Normal effect categories for different combinations of effect owner and hit target. Also has some common hit conditions that can't easily be tracked by EffectConditions

TODO:
Documentation
EffectLifecycleEffect, which activates effects based on it's own lifecycle. Mostly useful with status effects. Might not actually need events to work.