### PR TITLE
Attribute effects

### DIFF
--- a/Conditions.md
+++ b/Conditions.md
@@ -23,3 +23,128 @@ The example below checks if the current in-game time is between 2am and 10 am.
   <EndHour>10</EndHour>
 </SL_Condition>
 ```
+
+--------
+
+### SL_CanSpendAttributeCondition
+Checks whether the owner can pay a given attribute cost. For use with `SL_SpendAttributeEffect`.
+
+| Parameter Name | Description |
+| ---| ------------- |
+| Cost | The cost to spend |
+| Attr | Which attribute to spend |
+| Relative | Whether the cost should be relative to the attribute's Max or not |
+| BurnedMax | If Relative, whether the Max should account for Burn or not|
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<SL_Effect xsi:type="SL_SpendAttributeEffect">
+  <Delay>0</Delay>
+  <SyncType>OwnerSync</SyncType>
+  <OverrideCategory>None</OverrideCategory>
+  <Cost>20</Cost>
+  <Attr>MANA</Attr>
+  <Relative>false</Relative>
+  <BurnedMax>false</BurnedMax>
+</SL_Effect>
+```
+
+--------
+
+### SL_CurrentAttributeCondition
+Checks the value of an attribute of the target's against a value and an operator.
+
+| Parameter Name | Description |
+| ---| ------------- |
+| Attr | Which attribute to check |
+| CompareType | Comparator to use between Attr and Value |
+| Value | Value to check against |
+| Owner | Whether to check on the effect owner or the target |
+| Relative | Whether the attribute value should be relative to the attribute's Max or not |
+| BurnedMax | If Relative, whether the Max should account for Burn or not|
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<SL_EffectCondition xsi:type="SL_CurrentAttributeCondition">
+  <Invert>false</Invert>
+  <Attr>STAMINA</Attr>
+  <Value>10</Value>
+  <CompareType>Greater</CompareType>
+  <Owner>false</Owner>
+  <Relative>true</Relative>
+  <BurnedMax>true</BurnedMax>
+</SL_EffectCondition>
+```
+
+--------
+
+### SL_CurrentAttributeRelativeCondition
+Checks the value of an attribute of the target's against a the value of another attribute and an operator.
+
+| Parameter Name | Description |
+| ---| ------------- |
+| AttrLeft | First attribute to check |
+| CompareType | Comparator to use between Attr and Value |
+| AttrRight | Second attribute to check |
+| Owner | Whether to check on the effect owner or the target |
+| Relative | Whether the attribute value should be relative to the attribute's Max or not |
+| BurnedMax | If Relative, whether the Max should account for Burn or not|
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<SL_EffectCondition xsi:type="SL_CurrentAttributeRelativeCondition">
+  <Invert>false</Invert>
+  <AttrLeft>STAMINA</AttrLeft>
+  <AttrRight>MANA</AttrRight>
+  <CompareType>Greater</CompareType>
+  <Owner>false</Owner>
+  <Relative>true</Relative>
+  <BurnedMax>true</BurnedMax>
+</SL_EffectCondition>
+```
+
+--------
+
+### SL_StatCondition
+Checks the value of a stat of the target's against a value and an operator.
+
+| Parameter Name | Description |
+| ---| ------------- |
+| Stat | Which stat to check |
+| CompareType | Comparator to use between Stat and Value |
+| Value | Value to check against |
+| Owner | Whether to check on the effect owner or the target |
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<SL_EffectCondition xsi:type="SL_StatCondition">
+  <Invert>false</Invert>
+  <Stat>MaxMana</Stat>
+  <Value>100</Value>
+  <CompareType>Greater</CompareType>
+  <Owner>false</Owner>
+</SL_EffectCondition>
+```
+
+--------
+
+### SL_StatRelativeCondition
+Checks the value of a stat of the target's against a the value of another stat and an operator.
+
+| Parameter Name | Description |
+| ---| ------------- |
+| StatLeft | First attribute to check |
+| CompareType | Comparator to use between Attr and Value |
+| StatRight | Second attribute to check |
+| Owner | Whether to check on the effect owner or the target |
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<SL_EffectCondition xsi:type="SL_StatRelativeCondition">
+  <Invert>false</Invert>
+  <StatLeft>MaxMana</StatLeft>
+  <StatRight>MaxStamina</StatRight>
+  <CompareType>Greater</CompareType>
+  <Owner>false</Owner>
+</SL_EffectCondition>
+```

--- a/Conditions.md
+++ b/Conditions.md
@@ -31,7 +31,7 @@ Checks whether the owner can pay a given attribute cost. For use with `SL_SpendA
 
 | Parameter Name | Description |
 | ---| ------------- |
-| Cost | The cost to spend |
+| Value | The cost to spend |
 | Attr | Which attribute to spend |
 | Relative | Whether the cost should be relative to the attribute's Max or not |
 | BurnedMax | If Relative, whether the Max should account for Burn or not|
@@ -42,7 +42,7 @@ Checks whether the owner can pay a given attribute cost. For use with `SL_SpendA
   <Delay>0</Delay>
   <SyncType>OwnerSync</SyncType>
   <OverrideCategory>None</OverrideCategory>
-  <Cost>20</Cost>
+  <Value>20</Value>
   <Attr>MANA</Attr>
   <Relative>false</Relative>
   <BurnedMax>false</BurnedMax>

--- a/Documentation.md
+++ b/Documentation.md
@@ -783,6 +783,7 @@ Spends Health, Mana, Stamina, or one of their Burns as though a cost for a skill
 | BurnedMax | If Relative, whether the Max should account for Burn or not|
 
 ```xml
+<?xml version="1.0" encoding="utf-8" ?>
 <SL_Effect xsi:type="SL_SpendAttributeEffect">
   <Delay>0</Delay>
   <SyncType>OwnerSync</SyncType>
@@ -815,6 +816,7 @@ Applies subeffects scaled to the value of a stat of the target. Like leveled pas
 | Owner | Whether scaling should be based on the effect owner's stats instead |
 
 ```xml
+<?xml version="1.0" encoding="utf-8" ?>
 <SL_Effect xsi:type="SL_StatScalingEffect">
   <Delay>0</Delay>
   <SyncType>OwnerSync</SyncType>
@@ -863,6 +865,7 @@ Similar to `SL_StatScalingEffect` above, but scaling off of an attribute instead
 | Round | Whether scaling should only increase at integer multiples of BaselineValue |
 
 ```xml
+<?xml version="1.0" encoding="utf-8" ?>
 <SL_Effect xsi:type="SL_CurrentAttributeScalingEffect">
   <Delay>0</Delay>
   <SyncType>OwnerSync</SyncType>

--- a/Documentation.md
+++ b/Documentation.md
@@ -777,7 +777,7 @@ Spends Health, Mana, Stamina, or one of their Burns as though a cost for a skill
 
 | Parameter Name | Description |
 | --- | ------------- | 
-| Cost | The cost to spend |
+| Value | The cost to spend |
 | Attr | Which attribute to spend |
 | Relative | Whether the cost should be relative to the attribute's Max or not |
 | BurnedMax | If Relative, whether the Max should account for Burn or not|
@@ -788,7 +788,7 @@ Spends Health, Mana, Stamina, or one of their Burns as though a cost for a skill
   <Delay>0</Delay>
   <SyncType>OwnerSync</SyncType>
   <OverrideCategory>None</OverrideCategory>
-  <Cost>0.5</Cost>
+  <Value>0.5</Value>
   <Attr>STAMINA</Attr>
   <Relative>false</Relative>
   <BurnedMax>false</BurnedMax>
@@ -881,7 +881,7 @@ Similar to `SL_StatScalingEffect` above, but scaling off of an attribute instead
   <EffectBehavior>Destroy</EffectBehavior>
   <ChildEffects>
     <SL_EffectTransform>
-      <TransformName>Normal Cost</TransformName>
+      <TransformName>Normal Value</TransformName>
       <Position xsi:nil="true" />
       <Rotation xsi:nil="true" />
       <Scale xsi:nil="true" />
@@ -890,7 +890,7 @@ Similar to `SL_StatScalingEffect` above, but scaling off of an attribute instead
           <Delay>0</Delay>
           <SyncType>OwnerSync</SyncType>
           <OverrideCategory>None</OverrideCategory>
-          <Cost>20</Cost>
+          <Value>20</Value>
           <Attr>MANA</Attr>
           <Relative>false</Relative>
           <BurnedMax>false</BurnedMax>

--- a/Documentation.md
+++ b/Documentation.md
@@ -768,3 +768,139 @@ Deals damage to the AffectedCharacter based on the currently equipped weapon.
   <HitInventory>false</HitInventory>
 </SL_Effect>
 ```
+
+--------------
+
+### SL_SpendAttributeEffect
+
+Spends Health, Mana, Stamina, or one of their Burns as though a cost for a skill. Only affects the effect owner. Mana and Stamina costs respect their cost reductions. Optionally, costs can be a percentage of the base or effective maximum for the attribute.
+
+| Parameter Name | Description |
+| --- | ------------- | 
+| Cost | The cost to spend |
+| Attr | Which attribute to spend |
+| Relative | Whether the cost should be relative to the attribute's Max or not |
+| BurnedMax | If Relative, whether the Max should account for Burn or not|
+
+```xml
+<SL_Effect xsi:type="SL_SpendAttributeEffect">
+  <Delay>0</Delay>
+  <SyncType>OwnerSync</SyncType>
+  <OverrideCategory>None</OverrideCategory>
+  <Cost>0.5</Cost>
+  <Attr>STAMINA</Attr>
+  <Relative>false</Relative>
+  <BurnedMax>false</BurnedMax>
+</SL_Effect>
+```
+
+--------------
+
+### SL_StatScalingEffect
+
+Applies subeffects scaled to the value of a stat of the target. Like leveled passives, only works for the following effects:
+
+    AffectStat
+    AffectNeed and similar
+    AffectStatusEffectBuildUpResistance
+    AffectCooldown
+    SpendAttributeEffect
+
+
+| Parameter Name | Description |
+| --- | ------------- | 
+| Stat | The Stat Tag to base effect potency on |
+| BaselineValue | The Stat value at which effects should be applied at 100% potency |
+| Round | Whether scaling should only increase at integer multiples of BaselineValue |
+| Owner | Whether scaling should be based on the effect owner's stats instead |
+
+```xml
+<SL_Effect xsi:type="SL_StatScalingEffect">
+  <Delay>0</Delay>
+  <SyncType>OwnerSync</SyncType>
+  <OverrideCategory>None</OverrideCategory>
+  <EffectBehavior>Destroy</EffectBehavior>
+  <ChildEffects>
+    <SL_EffectTransform>
+      <TransformName>Normal</TransformName>
+      <Position xsi:nil="true" />
+      <Rotation xsi:nil="true" />
+      <Scale xsi:nil="true" />
+      <Effects>
+        <SL_Effect xsi:type="SL_AffectStat">
+          <Delay>0</Delay>
+          <SyncType>OwnerSync</SyncType>
+          <OverrideCategory>None</OverrideCategory>
+          <Stat_Tag>StaminaRegen</Stat_Tag>
+          <AffectQuantity>10</AffectQuantity>
+          <IsModifier>true</IsModifier>
+          <Duration>-1</Duration>
+        </SL_Effect>
+      </Effects>
+    </SL_EffectTransform>
+  </ChildEffects>
+  <ActivationLimit>0</ActivationLimit>
+  <Stat>MaxMana</Stat>
+  <BaselineValue>20</BaselineValue>
+  <Round>false</Round>
+  <Owner>false</Owner>
+</SL_Effect>
+```
+
+--------------
+
+### SL_CurrentAttributeScalingEffect
+
+Similar to `SL_StatScalingEffect` above, but scaling off of an attribute instead. 
+
+| Parameter Name | Description |
+| --- | ------------- | 
+| BaselineValue | The attribute value at which effects should be applied at 100% potency |
+| Attr | Which attribute to base scaling off of |
+| Relative | Whether the scaling should be relative to the attribute's Max or not |
+| BurnedMax | If Relative, whether the Max should account for Burn or not|
+| Owner | Whether scaling should be based on the effect owner's attribute instead |
+| Round | Whether scaling should only increase at integer multiples of BaselineValue |
+
+```xml
+<SL_Effect xsi:type="SL_CurrentAttributeScalingEffect">
+  <Delay>0</Delay>
+  <SyncType>OwnerSync</SyncType>
+  <OverrideCategory>None</OverrideCategory>
+  <CastPosition>Local</CastPosition>
+  <LocalPositionAdd>
+    <x>0</x>
+    <y>0</y>
+    <z>0</z>
+  </LocalPositionAdd>
+  <NoAim>false</NoAim>
+  <TargetType>Enemies</TargetType>
+  <EffectBehavior>Destroy</EffectBehavior>
+  <ChildEffects>
+    <SL_EffectTransform>
+      <TransformName>Normal Cost</TransformName>
+      <Position xsi:nil="true" />
+      <Rotation xsi:nil="true" />
+      <Scale xsi:nil="true" />
+      <Effects>
+        <SL_Effect xsi:type="SL_SpendAttributeEffect">
+          <Delay>0</Delay>
+          <SyncType>OwnerSync</SyncType>
+          <OverrideCategory>None</OverrideCategory>
+          <Cost>20</Cost>
+          <Attr>MANA</Attr>
+          <Relative>false</Relative>
+          <BurnedMax>false</BurnedMax>
+        </SL_Effect>
+      </Effects>
+    </SL_EffectTransform>
+  </ChildEffects>
+  <ActivationLimit>0</ActivationLimit>
+  <BaselineValue>20</BaselineValue>
+  <Round>false</Round>
+  <Attr>MANA</Attr>
+  <Owner>true</Owner>
+  <Relative>false</Relative>
+  <BurnedMax>false</BurnedMax>
+</SL_Effect>
+```

--- a/src/Events/BlockEvent.cs
+++ b/src/Events/BlockEvent.cs
@@ -1,0 +1,54 @@
+using System;
+using HarmonyLib;
+using UnityEngine;
+
+namespace SideLoader_ExtendedEffects.Events {
+
+    public struct BlockEvent {
+        public Character dealer;
+        public Character target;
+        public float damage;
+        public Vector3 hitDirection;
+        public float angle;
+        public float angleDirection;
+        public EffectSynchronizer source;
+        public float knockback;
+    }
+
+    [HarmonyPatch(typeof(Character), nameof(Character.ReceiveBlock), argumentTypes:new Type[]{
+        typeof(UnityEngine.MonoBehaviour),
+        typeof(float),
+        typeof(Vector3),
+        typeof(float),
+        typeof(float),
+        typeof(Character),
+        typeof(float)
+    })]
+    public class Character_ReceiveBlock_Postfix
+    {
+        static void Postfix(
+            Character __instance,
+            UnityEngine.MonoBehaviour hitBehaviour,
+            float _damage,
+            Vector3 _hitDir,
+            float _angle,
+            float _angleDir,
+            Character _dealerChar,
+            float _knockBack
+        )
+        {
+            var e =  new BlockEvent {
+                dealer   = _dealerChar,
+                target  = __instance,
+                damage = _damage,
+                hitDirection = _hitDir,
+                angle = _angle,
+                angleDirection = _angleDir,
+                source = hitBehaviour as EffectSynchronizer,
+                knockback = _knockBack
+            };
+            Publisher<BlockEvent>.RaiseEvent(e);
+        }
+    }
+
+}

--- a/src/OutwardHelpers.cs
+++ b/src/OutwardHelpers.cs
@@ -93,4 +93,16 @@ namespace SideLoader_ExtendedEffects
             return default(Tag);
         }
     }
+
+    public enum Attributes
+    {
+        HEALTH,
+        MANA,
+        STAMINA
+    }
+    public enum DamageSourceType {
+        ANY,
+        WEAPON,
+        NON_WEAPON
+    }
 }

--- a/src/OutwardHelpers.cs
+++ b/src/OutwardHelpers.cs
@@ -98,7 +98,10 @@ namespace SideLoader_ExtendedEffects
     {
         HEALTH,
         MANA,
-        STAMINA
+        STAMINA,
+        BURNT_HEALTH,
+        BURNT_MANA,
+        BURNT_STAMINA
     }
     public enum DamageSourceType {
         ANY,

--- a/src/Released/Conditions/SL_CanSpendAttributeCondition.cs
+++ b/src/Released/Conditions/SL_CanSpendAttributeCondition.cs
@@ -1,0 +1,79 @@
+using SideLoader;
+using System;
+namespace SideLoader_ExtendedEffects.Released.Conditions
+{
+    public class SL_CanSpendAttributeCondition : SL_EffectCondition, ICustomModel
+    {
+        public Type SLTemplateModel => typeof(SL_CanSpendAttributeCondition);
+        public Type GameModel => typeof(CanSpendAttributeCondition);
+
+        public Attributes Attr; // Attribute to compare to
+        public float Cost; // Cost to compare
+        public bool Relative; // If the comparison should be relative to max
+        public bool BurnedMax; // Whether the relative comparison should respect the burned max. Ignored for burned attributes
+        public override void ApplyToComponent<T>(T component)
+        {
+            var comp = component as CanSpendAttributeCondition;
+            comp.Attr = this.Attr;
+            comp.Cost = this.Cost;
+            comp.Relative = this.Relative;
+            comp.BurnedMax = this.BurnedMax;
+        }
+        public override void SerializeEffect<T>(T effect)
+        {
+            var comp = effect as CanSpendAttributeCondition;
+            this.Attr = comp.Attr;
+            this.Cost = comp.Cost;
+            this.Relative = comp.Relative;
+            this.BurnedMax = comp.BurnedMax;
+        }
+
+    }
+
+    public class CanSpendAttributeCondition : EffectCondition
+    {
+        public Attributes Attr;
+        public float Cost;
+        public bool Relative; 
+        public bool BurnedMax;
+
+        public override bool CheckIsValid(Character _affectedCharacter)
+        {
+            Character character =  this.m_parentSynchronizer.OwnerCharacter;
+            if (!(character && character.Stats)) return false;
+            float realCost = Cost;
+            float currentPool;
+            switch (Attr){
+                case Attributes.HEALTH:
+                    if (Relative) realCost = (realCost / 100) * (BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth);
+                    currentPool = character.Stats.CurrentHealth;
+                    break;
+                case Attributes.MANA:
+                    if (Relative) realCost = (realCost / 100) * (BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana);
+                    realCost = character.Stats.GetFinalManaConsumption(null, realCost);
+                    currentPool = character.Stats.CurrentMana;
+                    break;
+                case Attributes.STAMINA:
+                    if (Relative) realCost = (realCost / 100) * (BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina);
+                    realCost = character.Stats.GetFinalStaminaConsumption(null, realCost);
+                    currentPool = character.Stats.CurrentStamina;
+                    break;
+                case Attributes.BURNT_HEALTH:
+                    if (Relative) realCost =  (realCost / 100) * (BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth);
+                    currentPool = character.Stats.BurntHealth;
+                    break;
+                case Attributes.BURNT_MANA:
+                    if (Relative) realCost =  (realCost / 100) * (BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana);
+                    currentPool = character.Stats.BurntMana;
+                    break;
+                case Attributes.BURNT_STAMINA:
+                    if (Relative) realCost =  (realCost / 100) * (BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina);
+                    currentPool = character.Stats.BurntStamina;
+                    break;
+                default:
+                    return false; // Misconfigured effect
+            }
+            return realCost <= currentPool;
+        }
+    }
+}

--- a/src/Released/Conditions/SL_CanSpendAttributeCondition.cs
+++ b/src/Released/Conditions/SL_CanSpendAttributeCondition.cs
@@ -8,14 +8,14 @@ namespace SideLoader_ExtendedEffects.Released.Conditions
         public Type GameModel => typeof(CanSpendAttributeCondition);
 
         public Attributes Attr; // Attribute to compare to
-        public float Cost; // Cost to compare
+        public float Value; // Value to compare
         public bool Relative; // If the comparison should be relative to max
         public bool BurnedMax; // Whether the relative comparison should respect the burned max. Ignored for burned attributes
         public override void ApplyToComponent<T>(T component)
         {
             var comp = component as CanSpendAttributeCondition;
             comp.Attr = this.Attr;
-            comp.Cost = this.Cost;
+            comp.Value = this.Value;
             comp.Relative = this.Relative;
             comp.BurnedMax = this.BurnedMax;
         }
@@ -23,7 +23,7 @@ namespace SideLoader_ExtendedEffects.Released.Conditions
         {
             var comp = effect as CanSpendAttributeCondition;
             this.Attr = comp.Attr;
-            this.Cost = comp.Cost;
+            this.Value = comp.Value;
             this.Relative = comp.Relative;
             this.BurnedMax = comp.BurnedMax;
         }
@@ -33,7 +33,7 @@ namespace SideLoader_ExtendedEffects.Released.Conditions
     public class CanSpendAttributeCondition : EffectCondition
     {
         public Attributes Attr;
-        public float Cost;
+        public float Value;
         public bool Relative; 
         public bool BurnedMax;
 
@@ -41,39 +41,39 @@ namespace SideLoader_ExtendedEffects.Released.Conditions
         {
             Character character =  this.m_parentSynchronizer.OwnerCharacter;
             if (!(character && character.Stats)) return false;
-            float realCost = Cost;
+            float realValue = Value;
             float currentPool;
             switch (Attr){
                 case Attributes.HEALTH:
-                    if (Relative) realCost = (realCost / 100) * (BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth);
+                    if (Relative) realValue = (realValue / 100) * (BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth);
                     currentPool = character.Stats.CurrentHealth;
                     break;
                 case Attributes.MANA:
-                    if (Relative) realCost = (realCost / 100) * (BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana);
-                    realCost = character.Stats.GetFinalManaConsumption(null, realCost);
+                    if (Relative) realValue = (realValue / 100) * (BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana);
+                    realValue = character.Stats.GetFinalManaConsumption(null, realValue);
                     currentPool = character.Stats.CurrentMana;
                     break;
                 case Attributes.STAMINA:
-                    if (Relative) realCost = (realCost / 100) * (BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina);
-                    realCost = character.Stats.GetFinalStaminaConsumption(null, realCost);
+                    if (Relative) realValue = (realValue / 100) * (BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina);
+                    realValue = character.Stats.GetFinalStaminaConsumption(null, realValue);
                     currentPool = character.Stats.CurrentStamina;
                     break;
                 case Attributes.BURNT_HEALTH:
-                    if (Relative) realCost =  (realCost / 100) * (BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth);
+                    if (Relative) realValue =  (realValue / 100) * (BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth);
                     currentPool = character.Stats.BurntHealth;
                     break;
                 case Attributes.BURNT_MANA:
-                    if (Relative) realCost =  (realCost / 100) * (BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana);
+                    if (Relative) realValue =  (realValue / 100) * (BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana);
                     currentPool = character.Stats.BurntMana;
                     break;
                 case Attributes.BURNT_STAMINA:
-                    if (Relative) realCost =  (realCost / 100) * (BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina);
+                    if (Relative) realValue =  (realValue / 100) * (BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina);
                     currentPool = character.Stats.BurntStamina;
                     break;
                 default:
                     return false; // Misconfigured effect
             }
-            return realCost <= currentPool;
+            return realValue <= currentPool;
         }
     }
 }

--- a/src/Released/Conditions/SL_CurrentAttributeCondition.cs
+++ b/src/Released/Conditions/SL_CurrentAttributeCondition.cs
@@ -1,0 +1,85 @@
+using SideLoader;
+using System;
+namespace SideLoader_ExtendedEffects.Released.Conditions
+{
+    public class SL_CurrentAttributeCondition : SL_EffectCondition, ICustomModel
+    {
+        public Type SLTemplateModel => typeof(SL_CurrentAttributeCondition);
+        public Type GameModel => typeof(CurrentAttributeCondition);
+
+        public Attributes Attr; // Attribute to compare
+        public float Value; // Value to compare to
+        public AICondition.NumericCompare CompareType;
+        public bool Owner; // If the comparison should target the owner or the target
+        public bool Relative; // If the comparison should be relative to max
+        public bool BurnedMax; // Whether the relative comparison should respect the burned max. Ignored for burned attributes
+        public override void ApplyToComponent<T>(T component)
+        {
+            var comp = component as CurrentAttributeCondition;
+            comp.Attr = this.Attr;
+            comp.Value = this.Value;
+            comp.CompareType = this.CompareType;
+            comp.Owner = this.Owner;
+            comp.Relative = this.Relative;
+            comp.BurnedMax = this.BurnedMax;
+        }
+        public override void SerializeEffect<T>(T effect)
+        {
+            var comp = effect as CurrentAttributeCondition;
+            this.Attr = comp.Attr;
+            this.Value = comp.Value;
+            this.CompareType = comp.CompareType;
+            this.Owner = comp.Owner;
+            this.Relative = comp.Relative;
+            this.BurnedMax = comp.BurnedMax;
+        }
+
+    }
+
+    public class CurrentAttributeCondition : EffectCondition
+    {
+        public Attributes Attr;
+        public float Value;
+        public AICondition.NumericCompare CompareType;
+        public bool Owner;
+        public bool Relative; 
+        public bool BurnedMax;
+
+        public override bool CheckIsValid(Character _affectedCharacter)
+        {
+            Character character = Owner ? this.m_parentSynchronizer.OwnerCharacter : _affectedCharacter;
+            if (!(character && character.Stats)) return false;
+            float attrVal;
+            switch (Attr)
+            {
+                case Attributes.HEALTH:
+                    attrVal = character.Stats.CurrentHealth;
+                    if (Relative) attrVal /= BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth;
+                    break;
+                case Attributes.MANA:
+                    attrVal = character.Stats.CurrentMana;
+                    if (Relative) attrVal /= BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana;
+                    break;
+                case Attributes.STAMINA:
+                    attrVal = character.Stats.CurrentStamina;
+                    if (Relative) attrVal /= BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina;
+                    break;
+                case Attributes.BURNT_HEALTH:
+                    attrVal = character.Stats.BurntHealth;
+                    if (Relative) attrVal /= character.Stats.MaxHealth;
+                    break;
+                case Attributes.BURNT_MANA:
+                    attrVal = character.Stats.BurntMana;
+                    if (Relative) attrVal /= character.Stats.MaxMana;
+                    break;
+                case Attributes.BURNT_STAMINA:
+                    attrVal = character.Stats.BurntStamina;
+                    if (Relative) attrVal /= character.Stats.MaxStamina;
+                    break;
+                default:
+                    return false; // Misconfigured condition
+            }
+            return AICondition.CompareFloats(attrVal, Relative ? this.Value / 100 : this.Value, this.CompareType);
+        }
+    }
+}

--- a/src/Released/Conditions/SL_CurrentAttributeRelativeCondition.cs
+++ b/src/Released/Conditions/SL_CurrentAttributeRelativeCondition.cs
@@ -1,0 +1,112 @@
+using SideLoader;
+using System;
+namespace SideLoader_ExtendedEffects.Released.Conditions
+{
+    public class SL_CurrentAttributeRelativeCondition : SL_EffectCondition, ICustomModel
+    {
+        public Type SLTemplateModel => typeof(SL_CurrentAttributeRelativeCondition);
+        public Type GameModel => typeof(CurrentAttributeRelativeCondition);
+
+        public Attributes LeftAttr; // Left hand attribute to compare
+        public Attributes RightAttr; // Right hand attribute to compare
+        public AICondition.NumericCompare CompareType;
+        public bool Owner; // If the comparison should target the owner or the target
+        public bool Relative; // If the comparison should be relative to max
+        public bool BurnedMax; // Whether the relative comparison should respect the burned max. Ignored for burned attributes
+        public override void ApplyToComponent<T>(T component)
+        {
+            var comp = component as CurrentAttributeRelativeCondition;
+            comp.LeftAttr = this.LeftAttr;
+            comp.RightAttr = this.RightAttr;
+            comp.CompareType = this.CompareType;
+            comp.Owner = this.Owner;
+            comp.Relative = this.Relative;
+            comp.BurnedMax = this.BurnedMax;
+        }
+        public override void SerializeEffect<T>(T effect)
+        {
+            var comp = effect as CurrentAttributeRelativeCondition;
+            this.LeftAttr = comp.LeftAttr;
+            this.RightAttr = comp.RightAttr;
+            this.CompareType = comp.CompareType;
+            this.Owner = comp.Owner;
+            this.Relative = comp.Relative;
+            this.BurnedMax = comp.BurnedMax;
+        }
+
+    }
+
+    public class CurrentAttributeRelativeCondition : EffectCondition
+    {
+        public Attributes LeftAttr;
+        public Attributes RightAttr;
+        public AICondition.NumericCompare CompareType;
+        public bool Owner;
+        public bool Relative; 
+        public bool BurnedMax;
+
+        public override bool CheckIsValid(Character _affectedCharacter)
+        {
+            Character character = Owner ? this.m_parentSynchronizer.OwnerCharacter : _affectedCharacter;
+            if (!(character && character.Stats)) return false;
+            float leftVal, rightVal;
+            switch (LeftAttr){
+                case Attributes.HEALTH:
+                    leftVal = character.Stats.CurrentHealth;
+                    if (Relative) leftVal /= BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth;
+                    break;
+                case Attributes.MANA:
+                    leftVal = character.Stats.CurrentMana;
+                    if (Relative) leftVal /= BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana;
+                    break;
+                case Attributes.STAMINA:
+                    leftVal = character.Stats.CurrentStamina;
+                    if (Relative) leftVal /= BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina;
+                    break;
+                case Attributes.BURNT_HEALTH:
+                    leftVal = character.Stats.CurrentHealth;
+                    if (Relative) leftVal /= character.Stats.BurntHealth;
+                    break;
+                case Attributes.BURNT_MANA:
+                    leftVal = character.Stats.CurrentMana;
+                    if (Relative) leftVal /= character.Stats.BurntMana;
+                    break;
+                case Attributes.BURNT_STAMINA:
+                    leftVal = character.Stats.CurrentStamina;
+                    if (Relative) leftVal /= character.Stats.BurntStamina;
+                    break;
+                default:
+                    return false; // Misconfigured condition
+            }
+            switch (RightAttr){
+                case Attributes.HEALTH:
+                    rightVal = character.Stats.CurrentHealth;
+                    if (Relative) rightVal /= BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth;
+                    break;
+                case Attributes.MANA:
+                    rightVal = character.Stats.CurrentMana;
+                    if (Relative) rightVal /= BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana;
+                    break;
+                case Attributes.STAMINA:
+                    rightVal = character.Stats.CurrentStamina;
+                    if (Relative) rightVal /= BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina;
+                    break;
+                case Attributes.BURNT_HEALTH:
+                    rightVal = character.Stats.BurntHealth;
+                    if (Relative) rightVal /= character.Stats.MaxHealth;
+                    break;
+                case Attributes.BURNT_MANA:
+                    rightVal = character.Stats.BurntMana;
+                    if (Relative) rightVal /= character.Stats.MaxMana;
+                    break;
+                case Attributes.BURNT_STAMINA:
+                    rightVal = character.Stats.BurntStamina;
+                    if (Relative) rightVal /= character.Stats.MaxStamina;
+                    break;
+                default:
+                    return false; // Misconfigured condition
+            }
+            return AICondition.CompareFloats(leftVal, rightVal, this.CompareType);
+        }
+    }
+}

--- a/src/Released/Conditions/SL_StatCondition.cs
+++ b/src/Released/Conditions/SL_StatCondition.cs
@@ -1,0 +1,47 @@
+using SideLoader;
+using System;
+namespace SideLoader_ExtendedEffects.Released.Conditions
+{
+    public class SL_StatCondition : SL_EffectCondition, ICustomModel
+    {
+        public Type SLTemplateModel => typeof(SL_StatCondition);
+        public Type GameModel => typeof(StatCondition);
+
+        public String Stat; // Stat to compare
+        public float Value; // Value to compare to
+        public AICondition.NumericCompare CompareType;
+        public bool Owner; // If the comparison should target the owner or the target
+
+        public override void ApplyToComponent<T>(T component)
+        {
+            var comp = component as StatCondition;
+            comp.Stat = OutwardHelpers.GetTagFromName(this.Stat);
+            comp.Value = this.Value;
+            comp.CompareType = this.CompareType;
+            comp.Owner = this.Owner;
+        }
+        public override void SerializeEffect<T>(T effect)
+        {
+            var comp = effect as StatCondition;
+            this.Stat = comp.Stat.TagName;
+            this.Value = comp.Value;
+            this.CompareType = comp.CompareType;
+            this.Owner = comp.Owner;
+        }
+
+    }
+
+    public class StatCondition : EffectCondition
+    {
+        public Tag Stat;
+        public float Value;
+        public AICondition.NumericCompare CompareType;
+        public bool Owner;
+
+        public override bool CheckIsValid(Character _affectedCharacter)
+        {
+            Character character = Owner ? this.m_parentSynchronizer.OwnerCharacter : _affectedCharacter;
+            return character && character.Stats && AICondition.CompareFloats(character.Stats.GetStatCurrentValue(Stat), this.Value, this.CompareType);
+        }
+    }
+}

--- a/src/Released/Conditions/SL_StatRelativeCondition.cs
+++ b/src/Released/Conditions/SL_StatRelativeCondition.cs
@@ -1,0 +1,47 @@
+using SideLoader;
+using System;
+namespace SideLoader_ExtendedEffects.Released.Conditions
+{
+    public class SL_StatRelativeCondition : SL_EffectCondition, ICustomModel
+    {
+        public Type SLTemplateModel => typeof(SL_StatRelativeCondition);
+        public Type GameModel => typeof(StatRelativeCondition);
+
+        public String StatLeft; // Stat on the left hand side of the comparator
+        public String StatRight; // Stat on the right hnd side of the comparator
+        public AICondition.NumericCompare CompareType;
+        public bool Owner; // If the comparison should target the owner or the target
+        public override void ApplyToComponent<T>(T component)
+        {
+            var comp = component as StatRelativeCondition;
+            comp.StatLeft = OutwardHelpers.GetTagFromName(this.StatLeft);
+            comp.StatRight = OutwardHelpers.GetTagFromName(this.StatRight);
+            comp.CompareType = this.CompareType;
+            comp.Owner = this.Owner;
+        }
+        public override void SerializeEffect<T>(T effect)
+        {
+            var comp = effect as StatRelativeCondition;
+            this.StatLeft = comp.StatLeft.TagName;
+            this.StatRight = comp.StatRight.TagName;
+            this.CompareType = comp.CompareType;
+            this.Owner = comp.Owner;
+        }
+
+    }
+
+    public class StatRelativeCondition : EffectCondition
+    {
+        public Tag StatLeft;
+        public Tag StatRight;
+        public AICondition.NumericCompare CompareType;
+        public bool Owner;
+
+        public override bool CheckIsValid(Character _affectedCharacter)
+        {
+            Character character = Owner ? this.m_parentSynchronizer.OwnerCharacter : _affectedCharacter;
+            return character && character.Stats
+                && AICondition.CompareFloats(character.Stats.GetStatCurrentValue(StatLeft), character.Stats.GetStatCurrentValue(StatLeft), this.CompareType);
+        }
+    }
+}

--- a/src/Released/ContainerEffects/CurrentAttributeScalingEffect.cs
+++ b/src/Released/ContainerEffects/CurrentAttributeScalingEffect.cs
@@ -1,0 +1,100 @@
+using SideLoader;
+using System;
+
+namespace SideLoader_ExtendedEffects.Containers
+{
+
+    public class SL_CurrentAttributeScalingEffect: SL_ParentEffect {
+
+        public float BaselineValue; // Value of attribute at which effects will be applied at 100% potency
+        public bool Round; // Whether the scaling modifier should round down to integer multiples of the baseline or not
+        public Attributes Attr; // Attribute to base off of
+        public bool Owner; // Whether owner or target attribute should be used
+        public bool Relative; // Whether to base off of fraction of max attribute
+        public bool BurnedMax; // Whether the relative comparison should respect the burned max
+        public override void ApplyToComponent<T>(T component)
+        {
+            var comp = component as CurrentAttributeScalingEffect;
+            comp.Attr = this.Attr;
+            comp.Owner = this.Owner;
+            comp.Relative = this.Relative;
+            comp.BurnedMax = this.BurnedMax;
+            comp.Round = this.Round;
+            comp.BaselineValue = this.BaselineValue;
+        }
+        public override void SerializeEffect<T>(T effect)
+        {
+            var comp = effect as CurrentAttributeScalingEffect;
+            this.Attr = comp.Attr;
+            this.Owner = comp.Owner;
+            this.Relative = comp.Relative;
+            this.BurnedMax = comp.BurnedMax;
+            this.Round = comp.Round;
+            this.BaselineValue = comp.BaselineValue;
+        }
+
+    }
+
+
+    public class CurrentAttributeScalingEffect : ParentEffect, ICustomModel
+    {
+
+        public Type SLTemplateModel => typeof(SL_CurrentAttributeScalingEffect);
+        public Type GameModel => typeof(CurrentAttributeScalingEffect);
+
+        public float BaselineValue; // Value of attribute at which effects will be applied at 100% potency
+        public bool Round; // Whether the scaling modifier should round down to integer multiples of the baseline or not
+        public Attributes Attr; // Attribute to base off of
+        public bool Owner; // Whether owner or target attribute should be used
+        public bool Relative; // Whether to base off of fraction of max attribute
+        public bool BurnedMax; // Whether the relative comparison should respect the burned max
+        public override void ActivateLocally(Character _affectedCharacter, object[] _infos)
+        {
+            Character character = Owner ? this.m_parentSynchronizer.OwnerCharacter : _affectedCharacter;
+            if (!(character && character.Stats)) return;
+            float scale;
+            switch (Attr){
+                case Attributes.HEALTH:
+                    scale = character.Stats.CurrentHealth;
+                    if (Relative) scale /= BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth;
+                    break;
+                case Attributes.MANA:
+                    scale = character.Stats.CurrentMana;
+                    if (Relative) scale /= BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana;
+                    break;
+                case Attributes.STAMINA:
+                    scale = character.Stats.CurrentStamina;
+                    if (Relative) scale /= BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina;
+                    break;
+                case Attributes.BURNT_HEALTH:
+                    scale = character.Stats.CurrentHealth;
+                    if (Relative) scale /= character.Stats.MaxHealth;
+                    break;
+                case Attributes.BURNT_MANA:
+                    scale = character.Stats.CurrentMana;
+                    if (Relative) scale /= character.Stats.MaxMana;
+                    break;
+                case Attributes.BURNT_STAMINA:
+                    scale = character.Stats.CurrentStamina;
+                    if (Relative) scale /= character.Stats.MaxStamina;
+                    break;
+                default:
+                    return; // Misconfigured effect
+            }
+            scale /= Relative ? BaselineValue / 100 : BaselineValue;
+            if (Round)
+            {
+                scale = (float)Math.Floor((double)scale); // ew
+            }
+            this.m_subEffects[0].EffectPotency = scale;
+            StopApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Normal}, character);
+        }
+        public override void StopAffectLocally(Character _affectedCharacter)
+        {
+            Character character = Owner ? this.m_parentSynchronizer.OwnerCharacter : _affectedCharacter;
+            StopApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Normal}, character);
+            base.StopAffectLocally(character);
+        }
+    }
+
+}

--- a/src/Released/ContainerEffects/CurrentAttributeScalingEffect.cs
+++ b/src/Released/ContainerEffects/CurrentAttributeScalingEffect.cs
@@ -14,6 +14,7 @@ namespace SideLoader_ExtendedEffects.Containers
         public bool BurnedMax; // Whether the relative comparison should respect the burned max
         public override void ApplyToComponent<T>(T component)
         {
+            base.ApplyToComponent(component);
             var comp = component as CurrentAttributeScalingEffect;
             comp.Attr = this.Attr;
             comp.Owner = this.Owner;
@@ -24,6 +25,7 @@ namespace SideLoader_ExtendedEffects.Containers
         }
         public override void SerializeEffect<T>(T effect)
         {
+            base.SerializeEffect(effect);
             var comp = effect as CurrentAttributeScalingEffect;
             this.Attr = comp.Attr;
             this.Owner = comp.Owner;
@@ -41,7 +43,6 @@ namespace SideLoader_ExtendedEffects.Containers
 
         public Type SLTemplateModel => typeof(SL_CurrentAttributeScalingEffect);
         public Type GameModel => typeof(CurrentAttributeScalingEffect);
-
         public float BaselineValue; // Value of attribute at which effects will be applied at 100% potency
         public bool Round; // Whether the scaling modifier should round down to integer multiples of the baseline or not
         public Attributes Attr; // Attribute to base off of
@@ -67,15 +68,15 @@ namespace SideLoader_ExtendedEffects.Containers
                     if (Relative) scale /= BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina;
                     break;
                 case Attributes.BURNT_HEALTH:
-                    scale = character.Stats.CurrentHealth;
+                    scale = character.Stats.BurntHealth;
                     if (Relative) scale /= character.Stats.MaxHealth;
                     break;
                 case Attributes.BURNT_MANA:
-                    scale = character.Stats.CurrentMana;
+                    scale = character.Stats.BurntMana;
                     if (Relative) scale /= character.Stats.MaxMana;
                     break;
                 case Attributes.BURNT_STAMINA:
-                    scale = character.Stats.CurrentStamina;
+                    scale = character.Stats.BurntStamina;
                     if (Relative) scale /= character.Stats.MaxStamina;
                     break;
                 default:
@@ -87,12 +88,16 @@ namespace SideLoader_ExtendedEffects.Containers
                 scale = (float)Math.Floor((double)scale); // ew
             }
             this.m_subEffects[0].EffectPotency = scale;
-            StopApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Normal}, character);
+            foreach (EffectSynchronizer.EffectReference e in this.m_subEffects[0].m_effects.Values)
+            {
+                e.Effect.RefreshPotency();
+            }
+            StartApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Normal}, _affectedCharacter);
         }
         public override void StopAffectLocally(Character _affectedCharacter)
         {
             Character character = Owner ? this.m_parentSynchronizer.OwnerCharacter : _affectedCharacter;
-            StopApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Normal}, character);
+            StopApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Normal}, _affectedCharacter);
             base.StopAffectLocally(character);
         }
     }

--- a/src/Released/ContainerEffects/EffectLifecycleEffect.cs
+++ b/src/Released/ContainerEffects/EffectLifecycleEffect.cs
@@ -17,19 +17,19 @@ namespace SideLoader_ExtendedEffects.Containers
         public override void ActivateLocally(Character _affectedCharacter, object[] _infos)
         {
             if (!activated) {
-                this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Activation, this.OwnerCharacter);
+                StartApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Activation}, this.OwnerCharacter);
                 activated = true;
             }
-            this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Normal, this.OwnerCharacter);
+            StartApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Normal}, this.OwnerCharacter);
         }
         public override void StopAffectLocally(Character _affectedCharacter)
         {
-            this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Reference, this.OwnerCharacter);
+            StartApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Reference}, this.OwnerCharacter);
             this.activated = false; 
             
-            this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Reference, this.OwnerCharacter);
-            this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Activation, this.OwnerCharacter);
-            this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Normal, this.OwnerCharacter);
+            StopApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Reference}, this.OwnerCharacter);
+            StopApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Activation}, this.OwnerCharacter);
+            StopApply(new EffectSynchronizer.EffectCategories[]{EffectSynchronizer.EffectCategories.Normal}, this.OwnerCharacter);
             base.StopAffectLocally(_affectedCharacter);
         }
     }

--- a/src/Released/ContainerEffects/ParentEffect.cs
+++ b/src/Released/ContainerEffects/ParentEffect.cs
@@ -59,6 +59,8 @@ namespace SideLoader_ExtendedEffects.Containers
         public SubEffect ChildEffects;
         public int ActivationLimit;
 
+        public float Value = 0; // Yet another filthy hack
+
         private float lastApplyTime = 0;
         private Dictionary<Character, int> affectedThisInterval;
 

--- a/src/Released/ContainerEffects/ParentEffect.cs
+++ b/src/Released/ContainerEffects/ParentEffect.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace SideLoader_ExtendedEffects.Containers
 {
 
-    public abstract class SL_ParentEffect : SL_Effect
+    public abstract class SL_ParentEffect : SL_Shooter
     {
         public EditBehaviours EffectBehavior = EditBehaviours.Destroy;
         public SL_EffectTransform[] ChildEffects;
@@ -14,6 +14,7 @@ namespace SideLoader_ExtendedEffects.Containers
 
         public override void ApplyToComponent<T>(T component)
         {
+            base.ApplyToComponent(component);
             try {
                 var comp = component as ParentEffect;
 
@@ -30,6 +31,7 @@ namespace SideLoader_ExtendedEffects.Containers
 
         public override void SerializeEffect<T>(T effect)
         {
+            base.SerializeEffect(effect);
             try {
                 var comp = effect as ParentEffect;
                 if (comp.ChildEffects.transform.childCount > 0) {
@@ -63,8 +65,6 @@ namespace SideLoader_ExtendedEffects.Containers
         public override void Setup(Character.Factions[] _targetFactions, Transform _parent)
         {
             try {
-                SL.Log("Set Up");
-                SL.Log("own parent: " + this.m_parentSynchronizer.name);
                 base.Setup(_targetFactions, _parent);
                 
                 if (this.m_subEffects == null)
@@ -74,11 +74,9 @@ namespace SideLoader_ExtendedEffects.Containers
                     };
                 }
                 this.m_subEffects[0].gameObject.SetActive(true);
-                this.m_subEffects[0].Setup(this, 0, _targetFactions, _parent);
-                SL.Log(this.m_subEffects[0].m_parentEffect);
-                this.m_subEffects[0].m_parentEffect = this;
-                foreach (Effect effect in this.m_subEffects[0].transform.GetComponentsInChildren<Effect>()) {
-                    //effect.StartInit();
+                this.m_subEffects[0].Setup(this, 0, _targetFactions, base.transform); // Not an independent object, so it should attach to the skill transform tree
+                foreach (Shooter component in this.m_subEffects[0].GetComponentsInChildren<Shooter>(true)) {
+                    component.Setup(_targetFactions, _parent); // Raw SubEffect doesn't set up it's children, so we need to do this here
                 }
             } catch (Exception e) {
                 SL.Log("=========Setup Error!===========");
@@ -131,8 +129,22 @@ namespace SideLoader_ExtendedEffects.Containers
             }
         }
 
+        public virtual void StartApply(EffectSynchronizer.EffectCategories[] categories, Character affectedCharacter)
+        {
+            Vector3 pos = Vector3.zero;
+            Vector3 dir = Vector3.zero;
+            GetActivationInfos(affectedCharacter, ref pos, ref dir);
+            StartApply(categories, affectedCharacter, pos, dir);
+        }
+
         public virtual void Apply(EffectSynchronizer.EffectCategories[] categories, Character affectedCharacter, Vector3 pos, Vector3 dir) {
             StartApply(categories, affectedCharacter, pos, dir);
+            StopApply(categories, affectedCharacter);
+        }
+
+        public virtual void Apply(EffectSynchronizer.EffectCategories[] categories, Character affectedCharacter)
+        {
+            StartApply(categories, affectedCharacter); 
             StopApply(categories, affectedCharacter);
         }
 

--- a/src/Released/ContainerEffects/StatScalingEffect.cs
+++ b/src/Released/ContainerEffects/StatScalingEffect.cs
@@ -1,0 +1,66 @@
+using SideLoader;
+using System;
+
+namespace SideLoader_ExtendedEffects.Containers
+{
+
+    public class SL_StatScalingEffect: SL_ParentEffect {
+
+        public String Stat; // Name of tag to read value from
+        public float BaselineValue; // Value of Stat at which effects will be applied at 100% potency
+        public bool Round; // Whether the scaling modifier should round down to integer multiples of the baseline or not
+        public bool Owner; // Whether owner or target attribute should be used
+
+        public override void ApplyToComponent<T>(T component)
+        {
+            base.ApplyToComponent<T>(component);
+            var comp = component as StatScalingEffect;
+            comp.Stat = OutwardHelpers.GetTagFromName(this.Stat);
+            comp.BaselineValue = this.BaselineValue;
+            comp.Round = this.Round;
+            comp.Owner = this.Owner;
+        }
+        public override void SerializeEffect<T>(T effect)
+        {
+            base.SerializeEffect<T>(effect);
+            var comp = effect as StatScalingEffect;
+            this.Stat = comp.Stat.TagName;
+            this.BaselineValue = comp.BaselineValue;
+            this.Round = comp.Round;
+            this.Owner = comp.Owner;
+        }
+
+    }
+
+
+    public class StatScalingEffect : ParentEffect, ICustomModel
+    {
+
+        public Type SLTemplateModel => typeof(SL_StatScalingEffect);
+        public Type GameModel => typeof(StatScalingEffect);
+
+        public Tag Stat; // Tag to read value from
+        public float BaselineValue; // Value of Stat at which effects will be applied at 100% potency
+        public bool Round; // Whether the scaling modifier should round down to integer multiples of the baseline or not
+        public bool Owner; // Whether owner or target attribute should be used
+
+        public override void ActivateLocally(Character _affectedCharacter, object[] _infos)
+        {
+            Character character = Owner ? this.m_parentSynchronizer.OwnerCharacter : _affectedCharacter;
+            float scale = character.Stats.GetStatCurrentValue(Stat) / BaselineValue;
+            if (Round)
+            {
+                scale = (float)Math.Floor((double)scale); // ew
+            }
+            this.m_subEffects[0].EffectPotency = scale;
+            this.m_subEffects[0].SynchronizeEffects(EffectSynchronizer.EffectCategories.Normal, character);
+        }
+        public override void StopAffectLocally(Character _affectedCharacter)
+        {
+            Character character = Owner ? this.m_parentSynchronizer.OwnerCharacter : _affectedCharacter;
+            this.m_subEffects[0].StopAllEffects(EffectSynchronizer.EffectCategories.Normal, character);
+            base.StopAffectLocally(character);
+        }
+    }
+
+}

--- a/src/Released/ContainerEffects/TriggeredEffects/OnBlockEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/OnBlockEffect.cs
@@ -1,0 +1,89 @@
+using SideLoader_ExtendedEffects.Events;
+using SideLoader;
+using System;
+using System.Collections.Generic;
+
+namespace SideLoader_ExtendedEffects.Containers.Triggers
+{
+
+    public class SL_OnBlockEffect: SL_ParentEffect {
+        public DamageSourceType RequiredSourceType;
+
+        public override void ApplyToComponent<T>(T component)
+        {
+            base.ApplyToComponent<T>(component);
+            var comp = component as OnBlockEffect;
+            comp.RequiredSourceType = this.RequiredSourceType;
+        }
+        public override void SerializeEffect<T>(T effect)
+        {
+            base.SerializeEffect<T>(effect);
+            var comp = effect as OnBlockEffect;
+            this.RequiredSourceType = comp.RequiredSourceType;
+        }
+
+    }
+
+    public class OnBlockEffect : TriggeredEffect<BlockEvent>, ICustomModel
+    {
+        public Type SLTemplateModel => typeof(SL_OnBlockEffect);
+
+        public Type GameModel => typeof(OnBlockEffect);
+
+        public DamageSourceType RequiredSourceType;
+
+        public override void OnEvent(object sender, BlockEvent args)
+        {
+            try{
+                //Check if the hit was made with a weapon
+                if (
+                    (RequiredSourceType == DamageSourceType.NON_WEAPON && args.source is Weapon) ||
+                    (RequiredSourceType == DamageSourceType.WEAPON && !(args.source is Weapon))
+                )
+                {
+                    ExtendedEffects.Instance.DebugLogMessage("Wrong Hit Type");
+                    return; // Wrong type of hit
+                }
+
+                List<EffectSynchronizer.EffectCategories> dealerList = new List<EffectSynchronizer.EffectCategories>();
+                List<EffectSynchronizer.EffectCategories> targetList = new List<EffectSynchronizer.EffectCategories>();
+                if (args.target == this.OwnerCharacter) // Effect owner is the target
+                {
+                    try {
+                        // apply block effects to the source of the hit (usually an enemy hitting the buff owner)
+                        dealerList.Add(EffectSynchronizer.EffectCategories.Block);
+                        // apply reference effects to the target of the hit (the owner of the effect)
+                        targetList.Add(EffectSynchronizer.EffectCategories.Reference);
+                    } catch (Exception e) {
+                        ExtendedEffects.Instance.DebugLogMessage(e);
+                    }
+                }
+                if (args.dealer == this.OwnerCharacter) // Effect owner dealt the hit; 
+                {
+                    // Apply Hit effects to target
+                    targetList.Add(EffectSynchronizer.EffectCategories.Hit);
+                    // Apply Normal effects to source
+                    dealerList.Add(EffectSynchronizer.EffectCategories.Normal);
+                }
+                // Actually apply all of the required effects.
+                // Uses apply helper to make sure only one application per update happens
+                if (args.dealer == args.target)
+                {
+                    dealerList.AddRange(targetList);
+                    Apply(dealerList.ToArray(), args.dealer, args.dealer.CenterPosition, args.hitDirection);
+                }
+                else
+                {
+                    Apply(dealerList.ToArray(), args.dealer, args.dealer.CenterPosition, args.hitDirection);
+                    Apply(targetList.ToArray(), args.target, args.target.CenterPosition, args.hitDirection);
+                }
+            } catch (Exception e) {
+                ExtendedEffects.Instance.DebugLogMessage("=============Hit Event Error============");
+                ExtendedEffects.Instance.DebugLogMessage(e);
+            }
+            
+        }
+
+    }
+
+}

--- a/src/Released/ContainerEffects/TriggeredEffects/OnHitEffect.cs
+++ b/src/Released/ContainerEffects/TriggeredEffects/OnHitEffect.cs
@@ -7,7 +7,7 @@ namespace SideLoader_ExtendedEffects.Containers.Triggers
 {
 
     public class SL_OnHitEffect: SL_ParentEffect {
-        public OnHitEffect.DamageSourceType RequiredSourceType;
+        public DamageSourceType RequiredSourceType;
         public DamageType.Types[] DamageTypes;
         public bool RequireAllTypes;
         public int MinDamage;
@@ -47,12 +47,6 @@ namespace SideLoader_ExtendedEffects.Containers.Triggers
         public Type SLTemplateModel => typeof(SL_OnHitEffect);
 
         public Type GameModel => typeof(OnHitEffect);
-
-        public enum DamageSourceType {
-            ANY,
-            WEAPON,
-            NON_WEAPON
-        }
 
         public DamageSourceType RequiredSourceType;
         public DamageType.Types[] DamageTypes;

--- a/src/Released/SL_AffectCooldown.cs
+++ b/src/Released/SL_AffectCooldown.cs
@@ -52,10 +52,8 @@ namespace SideLoader_ExtendedEffects
             foreach (string uid in skills)
             {
                 Skill skill = ItemManager.Instance.GetItem(uid) as Skill;
-                SL.Log(skill.Name + " " + skill.ItemID);
                 if (AllowedSkills != null && AllowedSkills.Length > 0 && !AllowedSkills.Contains(skill.ItemID))
                 {
-                    SL.Log("Not Whitelisted");
                     continue; // Not an allowed skill
                 }
 

--- a/src/Released/SL_AffectCooldown.cs
+++ b/src/Released/SL_AffectCooldown.cs
@@ -58,6 +58,7 @@ namespace SideLoader_ExtendedEffects
                 }
 
                 float amount = IsModifier ? skill.RealCooldown * Amount/100 : Amount;
+                amount *= this.m_totalPotency;
                 skill.m_remainingCooldownTime -= amount;
                 skill.UpdateCooldownRatio();
             }

--- a/src/Released/SL_SpendAttributeEffect.cs
+++ b/src/Released/SL_SpendAttributeEffect.cs
@@ -6,7 +6,7 @@ namespace SideLoader_ExtendedEffects.Containers
 
     public class SL_SpendAttributeEffect: SL_Effect {
 
-        public float Cost; // Cost to spend
+        public float Value; // Value to spend
         public Attributes Attr; // Attribute to spend
         public bool Relative; // Whether to base off of fraction of max attribute
         public bool BurnedMax; // Whether the relative comparison should respect the burned max
@@ -16,7 +16,7 @@ namespace SideLoader_ExtendedEffects.Containers
             comp.Attr = this.Attr;
             comp.Relative = this.Relative;
             comp.BurnedMax = this.BurnedMax;
-            comp.Cost = this.Cost;
+            comp.Value = this.Value;
         }
         public override void SerializeEffect<T>(T effect)
         {
@@ -24,7 +24,7 @@ namespace SideLoader_ExtendedEffects.Containers
             this.Attr = comp.Attr;
             this.Relative = comp.Relative;
             this.BurnedMax = comp.BurnedMax;
-            this.Cost = comp.Cost;
+            this.Value = comp.Value;
         }
 
     }
@@ -36,7 +36,7 @@ namespace SideLoader_ExtendedEffects.Containers
         public Type SLTemplateModel => typeof(SL_SpendAttributeEffect);
         public Type GameModel => typeof(SpendAttributeEffect);
 
-        public float Cost;
+        public float Value;
         public Attributes Attr;
         public bool Relative; 
         public bool BurnedMax; 
@@ -44,31 +44,31 @@ namespace SideLoader_ExtendedEffects.Containers
         {
             Character character =  this.m_parentSynchronizer.OwnerCharacter;
             if (!(character && character.Stats)) return;
-            float realCost = Cost * this.m_totalPotency;
+            float realValue = Value * this.m_totalPotency;
             switch (Attr){
                 case Attributes.HEALTH:
-                    if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth;
-                    character.Stats.ReceiveDamage(realCost);
+                    if (Relative) realValue *= BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth;
+                    character.Stats.ReceiveDamage(realValue);
                     break;
                 case Attributes.MANA:
-                    if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana;
-                    character.Stats.UseMana(null, realCost);
+                    if (Relative) realValue *= BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana;
+                    character.Stats.UseMana(null, realValue);
                     break;
                 case Attributes.STAMINA:
-                    if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina;
-                    character.Stats.UseStamina(null, realCost, 1);
+                    if (Relative) realValue *= BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina;
+                    character.Stats.UseStamina(null, realValue, 1);
                     break;
                 case Attributes.BURNT_HEALTH:
-                    if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth;
-                    character.Stats.IncreaseBurntHealth(realCost);
+                    if (Relative) realValue *= BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth;
+                    character.Stats.IncreaseBurntHealth(realValue);
                     break;
                 case Attributes.BURNT_MANA:
-                    if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana;
-                    character.Stats.IncreaseBurntMana(realCost);
+                    if (Relative) realValue *= BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana;
+                    character.Stats.IncreaseBurntMana(realValue);
                     break;
                 case Attributes.BURNT_STAMINA:
-                    if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina;
-                    character.Stats.IncreaseBurntStamina(realCost);
+                    if (Relative) realValue *= BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina;
+                    character.Stats.IncreaseBurntStamina(realValue);
                     break;
                 default:
                     return; // Misconfigured effect

--- a/src/Released/SL_SpendAttributeEffect.cs
+++ b/src/Released/SL_SpendAttributeEffect.cs
@@ -1,0 +1,79 @@
+using SideLoader;
+using System;
+
+namespace SideLoader_ExtendedEffects.Containers
+{
+
+    public class SL_SpendAttributeEffect: SL_Effect {
+
+        public float Cost; // Cost to spend
+        public Attributes Attr; // Attribute to spend
+        public bool Relative; // Whether to base off of fraction of max attribute
+        public bool BurnedMax; // Whether the relative comparison should respect the burned max
+        public override void ApplyToComponent<T>(T component)
+        {
+            var comp = component as SpendAttributeEffect;
+            comp.Attr = this.Attr;
+            comp.Relative = this.Relative;
+            comp.BurnedMax = this.BurnedMax;
+            comp.Cost = this.Cost;
+        }
+        public override void SerializeEffect<T>(T effect)
+        {
+            var comp = effect as SpendAttributeEffect;
+            this.Attr = comp.Attr;
+            this.Relative = comp.Relative;
+            this.BurnedMax = comp.BurnedMax;
+            this.Cost = comp.Cost;
+        }
+
+    }
+
+
+    public class SpendAttributeEffect : Effect, ICustomModel
+    {
+
+        public Type SLTemplateModel => typeof(SL_SpendAttributeEffect);
+        public Type GameModel => typeof(SpendAttributeEffect);
+
+        public float Cost;
+        public Attributes Attr;
+        public bool Relative; 
+        public bool BurnedMax; 
+        public override void ActivateLocally(Character _affectedCharacter, object[] _infos)
+        {
+            Character character =  this.m_parentSynchronizer.OwnerCharacter;
+            if (!(character && character.Stats)) return;
+            float realCost = Cost;
+            switch (Attr){
+                case Attributes.HEALTH:
+                    if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth;
+                    character.Stats.ReceiveDamage(realCost);
+                    break;
+                case Attributes.MANA:
+                    if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana;
+                    character.Stats.UseMana(null, realCost);
+                    break;
+                case Attributes.STAMINA:
+                    if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina;
+                    character.Stats.UseStamina(null, realCost, 1);
+                    break;
+                case Attributes.BURNT_HEALTH:
+                    if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth;
+                    character.Stats.IncreaseBurntHealth(realCost);
+                    break;
+                case Attributes.BURNT_MANA:
+                    if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxMana : character.Stats.MaxMana;
+                    character.Stats.IncreaseBurntMana(realCost);
+                    break;
+                case Attributes.BURNT_STAMINA:
+                    if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxStamina : character.Stats.MaxStamina;
+                    character.Stats.IncreaseBurntStamina(realCost);
+                    break;
+                default:
+                    return; // Misconfigured effect
+            }
+        }
+    }
+
+}

--- a/src/Released/SL_SpendAttributeEffect.cs
+++ b/src/Released/SL_SpendAttributeEffect.cs
@@ -44,7 +44,7 @@ namespace SideLoader_ExtendedEffects.Containers
         {
             Character character =  this.m_parentSynchronizer.OwnerCharacter;
             if (!(character && character.Stats)) return;
-            float realCost = Cost;
+            float realCost = Cost * this.m_totalPotency;
             switch (Attr){
                 case Attributes.HEALTH:
                     if (Relative) realCost *= BurnedMax ? character.Stats.ActiveMaxHealth : character.Stats.MaxHealth;


### PR DESCRIPTION
Still writing the docs and looking for bugs, so there's a couple more commits coming in the next few days.

A whole bunch of new conditions and some effects to go with them, mostly pulled from the Mendicants rework I finally got time to do. Also fixed some longstanding issues with ParentEffects and not initializing nested SubEffect transforms correctly. 

### Known Issues:
- Some configurations don't (de)serialize correctly after a save, generating a ton of errors. Doesn't affect gameplay as far as I can tell, but makes troubleshooting other issues a pain.

### Features:
- A series of conditions that query current attributes or stats
    - StatCondition
        - Checks if the target's stat for a given Tag is matches the given value and predicate
        - Optionally checks the owner instead
    - StatRelativeCondition
        - As above, but the value is provided by a second stat tag
    - CurrentAttributeCondition
        - Checks if the given *current* value of an attribute matches the given value and predicate
        - Supports Health, Mana, Stamina, and their respective Burns
        - Supports absolute value or percentage of either Max or Active Max (Max minus Burn)
        - Optionally checks the owner instead
    - CurrentAttributeRelativeCondition
        - As above, but the value is provided by a second attributes current value
    - CanSpendAttributeCondition
        - Checks if the target could spend a given attribute as a cost.
        - Works for all of the above attributes and burns
        - Supports percentage costs
- A series of Effects that interact with Stats and Attributes
    - SpendAttributeEffect
        - Spends Health, Mana, Stamina, or their Burns as though they were a skill cost
        - Respects cost reductions
    - StatScalingEffect
        - A containter effect that applies it's Normal subeffects, but scaled to an Attribute at a given Tag, and with a given scaling factor.
        - Supports the same things as LevelPassiveSkills do, which isn't a lot
            - AffectStat
            - AffectNeed and similar
            - AffectStatusEffectBuildUpResistance
            - AffectCooldown
            - SpendAttributeEffect
    - CurrentAttributeScalingEffect
        - As a above, but scaled to a current attribute.
        - Supports all of the same settings as the above attribute conditions.
- OnBlockEffect, a counterpart of OnHitEffect that activates only on blocked hits.

### Bugfixes:
- Container effects no longer orphan their child effects, which was causing Shooter effects to break under most configurations
- Removed some of the more spammy debug logs

### Refactors:
- OnHitEffect.DamageSourceType enum is standalone now